### PR TITLE
Correct homepage: s/module-manager/modulemanager/

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "zf2",
         "modulemanager"
     ],
-    "homepage": "https://github.com/zendframework/zend-module-manager",
+    "homepage": "https://github.com/zendframework/zend-modulemanager",
     "autoload": {
         "psr-4": {
             "Zend\\ModuleManager\\": "src/"


### PR DESCRIPTION
Corrects the homepage in the `composer.json` to correctly reference `modulemanager` instead of `module-manager`.