### PR TITLE
Pin to versions of stdlib >=2.5.0, <2.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5",
         "zendframework/zend-eventmanager": "~2.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "zendframework/zend-stdlib": ">=2.5.0,<2.7.0"
     },
     "require-dev": {
         "zendframework/zend-config": "~2.5",


### PR DESCRIPTION
zend-stdlib 2.7.0 deprecates the hydrators; this change will ensure that only zend-stdlib based hydrators will work with this particular series, and will be used to tag version 2.5.2. A later pull request against develop will pin to `~2.7` and add zend-hydrator as a dependency, and be used for a new 2.6.0 version.