### PR TITLE
Updated zend-stdlib dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5",
         "zendframework/zend-eventmanager": "~2.5",
-        "zendframework/zend-stdlib": ">=2.5.0,<2.7.0"
+        "zendframework/zend-stdlib": "~2.7"
     },
     "require-dev": {
         "zendframework/zend-config": "~2.5",


### PR DESCRIPTION
Updated zend-stdlib to `~2.7` to allow usage with components that require that version or higher due to hydrator deprecation.