### PR TITLE
Reconfigure the service manager instead of aggregate config

### DIFF
--- a/src/Listener/ServiceListenerInterface.php
+++ b/src/Listener/ServiceListenerInterface.php
@@ -41,14 +41,11 @@ interface ServiceListenerInterface extends ListenerAggregateInterface
     public function setApplicationServiceManager($key, $moduleInterface, $method);
 
     /**
-     * Retrieve the aggregated configuration for the application service manager.
+     * Retrieve the application service manager instance post-configuration.
      *
-     * The array returned must be valid for passing to the service manager's
-     * constructor or withConfig() method.
-     *
-     * @return array
+     * @return ServiceManager
      */
-    public function getServiceManagerConfig();
+    public function getConfiguredServiceManager();
 
     /**
      * @param  array $configuration

--- a/test/Listener/TestAsset/SampleAbstractFactory.php
+++ b/test/Listener/TestAsset/SampleAbstractFactory.php
@@ -10,15 +10,18 @@
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 
 use Interop\Container\ContainerInterface;
+use stdClass;
 use Zend\ServiceManager\Factory\AbstractFactoryInterface;
 
 class SampleAbstractFactory implements AbstractFactoryInterface
 {
     public function canCreateServiceWithName(ContainerInterface $container, $name)
     {
+        return true;
     }
 
     public function __invoke(ContainerInterface $container, $name, array $options = [])
     {
+        return new stdClass;
     }
 }


### PR DESCRIPTION
The various plugin managers are built using configured services — but those services are typically not yet configured at the time the ServiceListener is invoked. As such, we need to re-configure the service manager prior to attempts to create the various plugin managers.

Since the logic is the same between merging configuration for the service manager as it is for plugin managers, I have extracted methods for this that each routine can invoke.

As such, the new workflow within `Zend\Mvc\Application` will be:

- Invoke `ModuleManagers::loadModules()`
- Check if the `ServiceListener` is present in the service manager; if so:
  - reset the service manager instance from the one returned from `ServiceListener::getConfiguredServiceManager()`

Finally, I've also added logic to *not* create a plugin manager if we did not receive any configuration for it.

This solves essentially the last problem I have with the zend-mvc/zend-servicemanager integration.