### PR TITLE
[3.x] Disable Zend\Loader by default and add option to enable it

### DIFF
--- a/src/Listener/DefaultListenerAggregate.php
+++ b/src/Listener/DefaultListenerAggregate.php
@@ -40,17 +40,22 @@ class DefaultListenerAggregate extends AbstractListener implements
     {
         $options                     = $this->getOptions();
         $configListener              = $this->getConfigListener();
-        $moduleLoaderListener        = new ModuleLoaderListener($options);
 
-        // High priority, we assume module autoloading (for FooNamespace\Module
-        // classes) should be available before anything else
-        $moduleLoaderListener->attach($events);
-        $this->listeners[] = $moduleLoaderListener;
+        if ($options->getUseZendLoader()) {
+            $moduleLoaderListener = new ModuleLoaderListener($options);
+
+            // High priority, we assume module autoloading (for FooNamespace\Module
+            // classes) should be available before anything else
+            $moduleLoaderListener->attach($events);
+            $this->listeners[] = $moduleLoaderListener;
+        }
         $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE_RESOLVE, new ModuleResolverListener);
 
-        // High priority, because most other loadModule listeners will assume
-        // the module's classes are available via autoloading
-        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, new AutoloaderListener($options), 9000);
+        if ($options->getUseZendLoader()) {
+            // High priority, because most other loadModule listeners will assume
+            // the module's classes are available via autoloading
+            $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, new AutoloaderListener($options), 9000);
+        }
 
         if ($options->getCheckDependencies()) {
             $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, new ModuleDependencyCheckerListener, 8000);

--- a/src/Listener/ListenerOptions.php
+++ b/src/Listener/ListenerOptions.php
@@ -68,6 +68,11 @@ class ListenerOptions extends AbstractOptions
     protected $moduleMapCacheKey;
 
     /**
+     * @var bool
+     */
+    protected $useZendLoader = false;
+
+    /**
      * Get an array of paths where modules reside
      *
      * @return array
@@ -378,6 +383,27 @@ class ListenerOptions extends AbstractOptions
     {
         $this->checkDependencies = (bool) $checkDependencies;
 
+        return $this;
+    }
+
+    public function getUseZendLoader()
+    {
+        return $this->useZendLoader;
+    }
+
+    /**
+     * Set if the module manager should use Zend\Loader
+     *
+     * Setting this option to false will disable ModuleAutoloader, requiring
+     * other means of autoloading to be used. Eg Composer.
+     * AutoloaderProvider feature will be disabled as well
+     *
+     * @param  bool $flag
+     * @return ListenerOptions
+     */
+    public function setUseZendLoader($flag)
+    {
+        $this->useZendLoader = (bool) $flag;
         return $this;
     }
 


### PR DESCRIPTION
_This is breaking change_ 
@weierophinney I need your input on this PR.

Disable dependency on zendframework/zend-loader by default and disable related features in favor of other means of autoloading. Eg Composer, which is now de-facto industry standard.

New `use_zend_loader` module manager option controls if Zend\Loader should be used.
Both ModuleAutoloader and AutoloaderProvider features are affected.

Example of config/application.config.php using zendframework/zend-loader:

``` php
<?php

return [
    'modules' => [
        'Application',
    ],
    'module_listener_options' => [
        'use_zend_loader' => true,
        // note that module paths only make sense if zend-loader is used
        'module_paths' => [
            './module',
            './vendor',
        ],
        'config_glob_paths' => [
            'config/autoload/{{,*.}global,{,*.}local}.php',
        ],
    ],
];
```

This PR replaces #4
Waiting for docs for the component to be merged.
