### PR TITLE
Compatibility with latest develop branch of ServiceManager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5",
         "zendframework/zend-eventmanager": "dev-develop as 2.7.0",
-        "zendframework/zend-stdlib": "~2.7"
+        "zendframework/zend-stdlib": "dev-develop as 2.8.0"
     },
     "require-dev": {
         "zendframework/zend-config": "dev-develop as 2.6.0",

--- a/src/Listener/ServiceListener.php
+++ b/src/Listener/ServiceListener.php
@@ -258,7 +258,7 @@ class ServiceListener implements ServiceListenerInterface
 
         // Register plugin managers as services in the application service manager
         if (! empty($pluginManagers)) {
-            $serviceManager = $serviceManager->withConfig(['services' => $pluginManagers]);
+            $serviceManager->configure(['services' => $pluginManagers]);
         }
 
         // Set the configured application service manager instance
@@ -306,7 +306,7 @@ class ServiceListener implements ServiceListenerInterface
     private function configureServiceManager(array $config)
     {
         if (! isset($this->serviceManagers[self::IS_APP_MANAGER])) {
-            return $this->defaultServiceManager->withConfig(['services' => [
+            return $this->defaultServiceManager->configure(['services' => [
                 'config' => $config,
             ]]);
         }
@@ -317,7 +317,7 @@ class ServiceListener implements ServiceListenerInterface
         $serviceConfig = $this->mergeServiceConfiguration(self::IS_APP_MANAGER, $metadata, $config);
         $serviceConfig['services']['config'] = $config;
 
-        return $services->withConfig($serviceConfig);
+        return $services->configure($serviceConfig);
     }
 
     /**

--- a/test/Listener/ServiceListenerTest.php
+++ b/test/Listener/ServiceListenerTest.php
@@ -122,14 +122,12 @@ class ServiceListenerTest extends TestCase
     {
         $this->listener->onLoadModulesPost($this->event);
         $services = $this->listener->getConfiguredServiceManager();
-        $this->assertNotSame($this->services, $services);
         $this->assertInstanceOf(ServiceManager::class, $services);
 
         $this->assertTrue($services->has(__CLASS__));
         $this->assertTrue($services->has('foo'));
         $this->assertTrue($services->has('bar'));
-        $this->assertFalse($services->has('resolved-by-abstract'));
-        $this->assertTrue($services->has('resolved-by-abstract', true));
+        $this->assertTrue($services->has('resolved-by-abstract'));
     }
 
     public function testModuleReturningArrayConfiguresServiceManager()
@@ -172,7 +170,6 @@ class ServiceListenerTest extends TestCase
         $this->listener->onLoadModulesPost($this->event);
 
         $services = $this->listener->getConfiguredServiceManager();
-        $this->assertNotSame($this->services, $services);
         $this->assertTrue($services->has('config'));
         $this->assertTrue($services->has('foo'));
         $this->assertNotSame($services->get('foo'), $services->get('bar'));
@@ -241,7 +238,7 @@ class ServiceListenerTest extends TestCase
     public function testCreatesPluginManagerBasedOnModuleImplementingSpecifiedProviderInterface()
     {
         $received = [];
-        $services = $this->services->withConfig(['factories' => [
+        $services = $this->services->configure(['factories' => [
             'CustomPluginManager' => function ($services, $name, array $options = null) use (&$received) {
                 $received = $options;
                 return new TestAsset\CustomPluginManager($services, $options);
@@ -264,7 +261,6 @@ class ServiceListenerTest extends TestCase
         $this->assertEquals($pluginConfig, $received);
 
         $configuredServices = $listener->getConfiguredServiceManager();
-        $this->assertNotSame($services, $configuredServices);
         $this->assertTrue($configuredServices->has('CustomPluginManager'));
         $plugins = $configuredServices->get('CustomPluginManager');
         $this->assertInstanceOf(TestAsset\CustomPluginManager::class, $plugins);
@@ -273,7 +269,7 @@ class ServiceListenerTest extends TestCase
     public function testCreatesPluginManagerBasedOnModuleDuckTypingSpecifiedProviderInterface()
     {
         $received = [];
-        $services = $this->services->withConfig(['factories' => [
+        $services = $this->services->configure(['factories' => [
             'CustomPluginManager' => function ($services, $name, array $options = null) use (&$received) {
                 $received = $options;
                 return new TestAsset\CustomPluginManager($services, $options);
@@ -296,7 +292,6 @@ class ServiceListenerTest extends TestCase
         $this->assertEquals($pluginConfig, $received);
 
         $configuredServices = $listener->getConfiguredServiceManager();
-        $this->assertNotSame($services, $configuredServices);
         $this->assertTrue($configuredServices->has('CustomPluginManager'));
         $plugins = $configuredServices->get('CustomPluginManager');
         $this->assertInstanceOf(TestAsset\CustomPluginManager::class, $plugins);


### PR DESCRIPTION
* replaced `withConfig` with `configure`
* fixed failing tests