### PR TITLE
Forwards compatibility with zend-(event|service)manager v3 releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,44 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+env:
+  global:
+    - EVENT_MANAGER_VERSION="^3.0"
+    - SERVICE_MANAGER_VERSION="^3.0.3"
+    - REMOVE_DEPS="zendframework/zend-mvc"
+
 matrix:
   fast_finish: true
   include:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - EVENT_MANAGER_VERSION="^2.6.2"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
+        - REMOVE_DEPS=""
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - EVENT_MANAGER_VERSION="^2.6.2"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
+        - REMOVE_DEPS=""
     - php: 7
+    - php: 7
+      env:
+        - EVENT_MANAGER_VERSION="^2.6.2"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
+        - REMOVE_DEPS=""
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - EVENT_MANAGER_VERSION="^2.6.2"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
+        - REMOVE_DEPS=""
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:
@@ -34,6 +59,9 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - composer require --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION"
+  - composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION"
+  - if [[ $REMOVE_DEPS != '' ]]; then composer remove --dev --no-update $REMOVE_DEPS ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 3.0.0 - TBD
+## 2.7.0 - TBD
 
 ### Added
 

--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,17 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-eventmanager": "dev-develop as 2.7.0",
-        "zendframework/zend-stdlib": "~2.7"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-config": "dev-develop as 2.6.0",
-        "zendframework/zend-console": "~2.5",
-        "zendframework/zend-di": "~2.5",
-        "zendframework/zend-loader": "~2.5",
-        "zendframework/zend-mvc": "~2.5",
-        "zendframework/zend-servicemanager": "dev-develop as 2.6.0",
+        "zendframework/zend-config": "^2.6",
+        "zendframework/zend-console": "^2.6",
+        "zendframework/zend-di": "^2.6",
+        "zendframework/zend-loader": "^2.5",
+        "zendframework/zend-mvc": "^2.6.3",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },
@@ -39,7 +39,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.6-dev",
-            "dev-develop": "3.0-dev"
+            "dev-develop": "2.7-dev"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "zendframework/zend-console": "^2.6",
         "zendframework/zend-di": "^2.6",
         "zendframework/zend-loader": "^2.5",
-        "zendframework/zend-mvc": "^2.6.3",
-        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+        "zendframework/zend-servicemanager": "^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/src/Feature/LocatorRegisteredInterface.php
+++ b/src/Feature/LocatorRegisteredInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ModuleManager\Feature;
+
+/**
+ * LocatorRegistered
+ *
+ * By implementing this interface in a Module class, the instance of the Module
+ * class will be automatically injected into any DI-configured object which has
+ * a constructor or setter parameter which is type hinted with the Module class
+ * name. Implementing this interface obviously does not require adding any
+ * methods to your class.
+ */
+interface LocatorRegisteredInterface
+{
+}

--- a/src/Listener/LocatorRegistrationListener.php
+++ b/src/Listener/LocatorRegistrationListener.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ModuleManager\Listener;
+
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\ListenerAggregateInterface;
+use Zend\ModuleManager\Feature\LocatorRegisteredInterface;
+use Zend\ModuleManager\ModuleEvent;
+use Zend\ModuleManager\ModuleManager;
+use Zend\Mvc\MvcEvent;
+
+/**
+ * Locator registration listener
+ */
+class LocatorRegistrationListener extends AbstractListener implements
+    ListenerAggregateInterface
+{
+    /**
+     * @var array
+     */
+    protected $modules = [];
+
+    /**
+     * @var array
+     */
+    protected $callbacks = [];
+
+    /**
+     * loadModule
+     *
+     * Check each loaded module to see if it implements LocatorRegistered. If it
+     * does, we add it to an internal array for later.
+     *
+     * @param  ModuleEvent $e
+     * @return void
+     */
+    public function onLoadModule(ModuleEvent $e)
+    {
+        if (! $e->getModule() instanceof LocatorRegisteredInterface) {
+            return;
+        }
+        $this->modules[] = $e->getModule();
+    }
+
+    /**
+     * loadModules
+     *
+     * Once all the modules are loaded, loop
+     *
+     * @param  ModuleEvent $e
+     * @return void
+     */
+    public function onLoadModules(ModuleEvent $e)
+    {
+        $moduleManager = $e->getTarget();
+        $events        = $moduleManager->getEventManager()->getSharedManager();
+
+        if (! $events) {
+            return;
+        }
+
+        // Shared instance for module manager
+        $events->attach('Zend\Mvc\Application', ModuleManager::EVENT_BOOTSTRAP, function (MvcEvent $e) use ($moduleManager) {
+            $moduleClassName      = get_class($moduleManager);
+            $moduleClassNameArray = explode('\\', $moduleClassName);
+            $moduleClassNameAlias = end($moduleClassNameArray);
+            $application          = $e->getApplication();
+            $services             = $application->getServiceManager();
+            if (! $services->has($moduleClassName)) {
+                $services->setAlias($moduleClassName, $moduleClassNameAlias);
+            }
+        }, 1000);
+
+        if (0 === count($this->modules)) {
+            return;
+        }
+
+        // Attach to the bootstrap event if there are modules we need to process
+        $events->attach('Zend\Mvc\Application', ModuleManager::EVENT_BOOTSTRAP, [$this, 'onBootstrap'], 1000);
+    }
+
+    /**
+     * Bootstrap listener
+     *
+     * This is ran during the MVC bootstrap event because it requires access to
+     * the DI container.
+     *
+     * @TODO: Check the application / locator / etc a bit better to make sure
+     * the env looks how we're expecting it to?
+     * @param MvcEvent $e
+     * @return void
+     */
+    public function onBootstrap(MvcEvent $e)
+    {
+        $application = $e->getApplication();
+        $services    = $application->getServiceManager();
+
+        foreach ($this->modules as $module) {
+            $moduleClassName = get_class($module);
+            if (! $services->has($moduleClassName)) {
+                $services->setService($moduleClassName, $module);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function attach(EventManagerInterface $events)
+    {
+        $this->callbacks[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, [$this, 'onLoadModule']);
+        $this->callbacks[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES, [$this, 'onLoadModules'], -1000);
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function detach(EventManagerInterface $events)
+    {
+        foreach ($this->callbacks as $index => $callback) {
+            if ($events->detach($callback)) {
+                unset($this->callbacks[$index]);
+            }
+        }
+    }
+}

--- a/src/Listener/ServiceListenerInterface.php
+++ b/src/Listener/ServiceListenerInterface.php
@@ -29,27 +29,8 @@ interface ServiceListenerInterface extends ListenerAggregateInterface
     public function addServiceManager($serviceManager, $key, $moduleInterface, $method);
 
     /**
-     * Provide metadata describing how to aggregate configuration for the application service manager.
-     *
-     * Sets the same metadata as used by addServiceManager(), using the key
-     * IS_APP_MANAGER for the service_manager value.
-     *
-     * @param  string $key             Configuration key
-     * @param  string $moduleInterface FQCN as string
-     * @param  string $method          Method name
-     */
-    public function setApplicationServiceManager($key, $moduleInterface, $method);
-
-    /**
-     * Retrieve the application service manager instance post-configuration.
-     *
-     * @return ServiceManager
-     */
-    public function getConfiguredServiceManager();
-
-    /**
      * @param  array $configuration
      * @return ServiceListenerInterface
      */
-    public function setDefaultServiceConfig(array $configuration);
+    public function setDefaultServiceConfig($configuration);
 }

--- a/test/Listener/ConfigListenerTest.php
+++ b/test/Listener/ConfigListenerTest.php
@@ -11,12 +11,12 @@ namespace ZendTest\ModuleManager\Listener;
 
 use ArrayObject;
 use InvalidArgumentException;
+use Zend\EventManager\Test\EventListenerIntrospectionTrait;
 use Zend\ModuleManager\Listener\ConfigListener;
 use Zend\ModuleManager\Listener\ModuleResolverListener;
 use Zend\ModuleManager\Listener\ListenerOptions;
 use Zend\ModuleManager\ModuleManager;
 use Zend\ModuleManager\ModuleEvent;
-use ZendTest\ModuleManager\EventManagerIntrospectionTrait;
 use ZendTest\ModuleManager\SetUpCacheDirTrait;
 
 /**
@@ -25,7 +25,7 @@ use ZendTest\ModuleManager\SetUpCacheDirTrait;
  */
 class ConfigListenerTest extends AbstractListenerTestCase
 {
-    use EventManagerIntrospectionTrait;
+    use EventListenerIntrospectionTrait;
     use SetUpCacheDirTrait;
 
     /**
@@ -174,10 +174,10 @@ class ConfigListenerTest extends AbstractListenerTestCase
     {
         $configListener = new ConfigListener;
         $configListener->addConfigStaticPaths([
-                __DIR__ . '/_files/good/config.ini',
-                __DIR__ . '/_files/good/config.php',
-                __DIR__ . '/_files/good/config.xml']
-                );
+            __DIR__ . '/_files/good/config.ini',
+            __DIR__ . '/_files/good/config.php',
+            __DIR__ . '/_files/good/config.xml'
+        ]);
 
         $moduleManager = $this->moduleManager;
         $moduleManager->setModules(['SomeModule']);
@@ -244,10 +244,10 @@ class ConfigListenerTest extends AbstractListenerTestCase
         ]);
         $configListener = new ConfigListener($options);
         $configListener->addConfigStaticPaths([
-                __DIR__ . '/_files/good/config.ini',
-                __DIR__ . '/_files/good/config.php',
-                __DIR__ . '/_files/good/config.xml']
-                );
+            __DIR__ . '/_files/good/config.ini',
+            __DIR__ . '/_files/good/config.php',
+            __DIR__ . '/_files/good/config.xml'
+        ]);
 
         $moduleManager = $this->moduleManager;
         $moduleManager->setModules(['SomeModule']);

--- a/test/Listener/DefaultListenerAggregateTest.php
+++ b/test/Listener/DefaultListenerAggregateTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\ModuleManager\Listener;
 
+use Zend\EventManager\Test\EventListenerIntrospectionTrait;
 use Zend\ModuleManager\Listener\ListenerOptions;
 use Zend\ModuleManager\Listener\DefaultListenerAggregate;
 use Zend\ModuleManager\ModuleManager;
@@ -20,7 +21,7 @@ use ZendTest\ModuleManager\EventManagerIntrospectionTrait;
  */
 class DefaultListenerAggregateTest extends AbstractListenerTestCase
 {
-    use EventManagerIntrospectionTrait;
+    use EventListenerIntrospectionTrait;
 
     /**
      * @var DefaultListenerAggregate

--- a/test/Listener/DefaultListenerAggregateTest.php
+++ b/test/Listener/DefaultListenerAggregateTest.php
@@ -13,7 +13,6 @@ use Zend\EventManager\Test\EventListenerIntrospectionTrait;
 use Zend\ModuleManager\Listener\ListenerOptions;
 use Zend\ModuleManager\Listener\DefaultListenerAggregate;
 use Zend\ModuleManager\ModuleManager;
-use ZendTest\ModuleManager\EventManagerIntrospectionTrait;
 
 /**
  * @covers Zend\ModuleManager\Listener\AbstractListener

--- a/test/Listener/LocatorRegistrationListenerTest.php
+++ b/test/Listener/LocatorRegistrationListenerTest.php
@@ -16,7 +16,6 @@ use Zend\ModuleManager\Listener\ModuleResolverListener;
 use Zend\ModuleManager\ModuleManager;
 use Zend\ModuleManager\ModuleEvent;
 use Zend\Mvc\Application;
-use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\ServiceManager;
 use ZendTest\ModuleManager\TestAsset\MockApplication;
 

--- a/test/Listener/LocatorRegistrationListenerTest.php
+++ b/test/Listener/LocatorRegistrationListenerTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ModuleManager\Listener;
+
+use Zend\EventManager\EventManager;
+use Zend\EventManager\SharedEventManager;
+use Zend\ModuleManager\Listener\LocatorRegistrationListener;
+use Zend\ModuleManager\Listener\ModuleResolverListener;
+use Zend\ModuleManager\ModuleManager;
+use Zend\ModuleManager\ModuleEvent;
+use Zend\Mvc\Application;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\ServiceManager;
+use ZendTest\ModuleManager\TestAsset\MockApplication;
+
+/**
+ * @covers Zend\ModuleManager\Listener\AbstractListener
+ * @covers Zend\ModuleManager\Listener\LocatorRegistrationListener
+ */
+class LocatorRegistrationListenerTest extends AbstractListenerTestCase
+{
+    /**
+     * @var Application
+     */
+    protected $application;
+
+    /**
+     * @var ModuleManager
+     */
+    protected $moduleManager;
+
+    /**
+     * @var ServiceManager
+     */
+    protected $serviceManager;
+
+    /**
+     * @var SharedEventManager
+     */
+    protected $sharedEvents;
+
+    public function setUp()
+    {
+        $this->sharedEvents = new SharedEventManager();
+
+        $this->moduleManager = new ModuleManager(['ListenerTestModule']);
+        $this->moduleManager->getEventManager()->setSharedManager($this->sharedEvents);
+        $this->moduleManager->getEventManager()->attach(ModuleEvent::EVENT_LOAD_MODULE_RESOLVE, new ModuleResolverListener, 1000);
+
+        $this->application = new MockApplication;
+        $events            = new EventManager(['Zend\Mvc\Application', 'ZendTest\Module\TestAsset\MockApplication', 'application']);
+        $events->setSharedManager($this->sharedEvents);
+        $this->application->setEventManager($events);
+
+        $this->serviceManager = new ServiceManager();
+        $this->serviceManager->setService('ModuleManager', $this->moduleManager);
+        $this->application->setServiceManager($this->serviceManager);
+    }
+
+    public function testModuleClassIsRegisteredWithDiAndInjectedWithSharedInstances()
+    {
+        $module  = null;
+        $locator = $this->serviceManager;
+        $locator->setFactory('Foo\Bar', function ($s) {
+            $module   = $s->get('ListenerTestModule\Module');
+            $manager  = $s->get('Zend\ModuleManager\ModuleManager');
+            $instance = new \Foo\Bar($module, $manager);
+            return $instance;
+        });
+
+        $locatorRegistrationListener = new LocatorRegistrationListener;
+        $events = $this->moduleManager->getEventManager();
+        $locatorRegistrationListener->attach($events);
+        $events->attach(ModuleEvent::EVENT_LOAD_MODULE, function (ModuleEvent $e) use (&$module) {
+            $module = $e->getModule();
+        }, -1000);
+        $this->moduleManager->loadModules();
+
+        $this->application->bootstrap();
+        $sharedInstance1 = $locator->get('ListenerTestModule\Module');
+        $sharedInstance2 = $locator->get(ModuleManager::class);
+
+        $this->assertInstanceOf('ListenerTestModule\Module', $sharedInstance1);
+        $foo     = false;
+        $message = '';
+        try {
+            $foo = $locator->get('Foo\Bar');
+        } catch (\Exception $e) {
+            $message = $e->getMessage();
+            while ($e = $e->getPrevious()) {
+                $message .= "\n" . $e->getMessage();
+            }
+        }
+        if (!$foo) {
+            $this->fail($message);
+        }
+        $this->assertSame($module, $foo->module);
+
+        $this->assertInstanceOf(ModuleManager::class, $sharedInstance2);
+        $this->assertSame($this->moduleManager, $locator->get('Foo\Bar')->moduleManager);
+    }
+
+    public function testNoDuplicateServicesAreDefinedForModuleManager()
+    {
+        $locatorRegistrationListener = new LocatorRegistrationListener;
+        $events = $this->moduleManager->getEventManager();
+        $locatorRegistrationListener->attach($events);
+
+        $this->moduleManager->loadModules();
+        $this->application->bootstrap();
+        $registeredServices = $this->application->getServiceManager()->getRegisteredServices();
+
+        $aliases = $registeredServices['aliases'];
+        $instances = $registeredServices['instances'];
+
+        $this->assertContains('zendmodulemanagermodulemanager', $aliases);
+        $this->assertNotContains('modulemanager', $aliases);
+
+        $this->assertContains('modulemanager', $instances);
+        $this->assertNotContains('zendmodulemanagermodulemanager', $instances);
+    }
+}

--- a/test/Listener/LocatorRegistrationListenerTest.php
+++ b/test/Listener/LocatorRegistrationListenerTest.php
@@ -48,6 +48,14 @@ class LocatorRegistrationListenerTest extends AbstractListenerTestCase
 
     public function setUp()
     {
+        if (! class_exists(Application::class)) {
+            $this->markTestSkipped(
+                'Skipping tests that rely on zend-mvc until that component is '
+                . 'updated to be forwards-compatible with zend-eventmanager and '
+                . 'zend-servicemanager v3 releases'
+            );
+        }
+
         $this->sharedEvents = new SharedEventManager();
 
         $this->moduleManager = new ModuleManager(['ListenerTestModule']);

--- a/test/Listener/ModuleLoaderListenerTest.php
+++ b/test/Listener/ModuleLoaderListenerTest.php
@@ -9,12 +9,12 @@
 
 namespace ZendTest\ModuleManager\Listener;
 
+use Zend\EventManager\Test\EventListenerIntrospectionTrait;
 use Zend\ModuleManager\Listener\ModuleResolverListener;
 use Zend\ModuleManager\Listener\ModuleLoaderListener;
 use Zend\ModuleManager\Listener\ListenerOptions;
 use Zend\ModuleManager\ModuleManager;
 use Zend\ModuleManager\ModuleEvent;
-use ZendTest\ModuleManager\EventManagerIntrospectionTrait;
 use ZendTest\ModuleManager\SetUpCacheDirTrait;
 
 /**
@@ -23,7 +23,7 @@ use ZendTest\ModuleManager\SetUpCacheDirTrait;
  */
 class ModuleLoaderListenerTest extends AbstractListenerTestCase
 {
-    use EventManagerIntrospectionTrait;
+    use EventListenerIntrospectionTrait;
     use SetUpCacheDirTrait;
 
     /**

--- a/test/Listener/OnBootstrapListenerTest.php
+++ b/test/Listener/OnBootstrapListenerTest.php
@@ -36,6 +36,14 @@ class OnBootstrapListenerTest extends AbstractListenerTestCase
 
     public function setUp()
     {
+        if (! class_exists(Application::class)) {
+            $this->markTestSkipped(
+                'Skipping tests that rely on zend-mvc until that component is '
+                . 'updated to be forwards-compatible with zend-eventmanager and '
+                . 'zend-servicemanager v3 releases'
+            );
+        }
+
         $sharedEvents = new SharedEventManager();
         $events       = new EventManager($sharedEvents);
         $this->moduleManager = new ModuleManager([]);

--- a/test/Listener/OnBootstrapListenerTest.php
+++ b/test/Listener/OnBootstrapListenerTest.php
@@ -45,10 +45,14 @@ class OnBootstrapListenerTest extends AbstractListenerTestCase
         $events->attach(ModuleEvent::EVENT_LOAD_MODULE, new OnBootstrapListener, 1000);
 
         $this->application = new MockApplication;
-        $appEvents         = new EventManager(
-            $sharedEvents,
-            ['Zend\Mvc\Application', 'ZendTest\Module\TestAsset\MockApplication', 'application']
-        );
+        $appEvents         = new EventManager();
+        $appEvents->setSharedManager($sharedEvents);
+        $appEvents->setIdentifiers([
+            'Zend\Mvc\Application',
+            'ZendTest\Module\TestAsset\MockApplication',
+            'application',
+        ]);
+            
         $this->application->setEventManager($appEvents);
     }
 

--- a/test/Listener/OnBootstrapListenerTest.php
+++ b/test/Listener/OnBootstrapListenerTest.php
@@ -60,7 +60,7 @@ class OnBootstrapListenerTest extends AbstractListenerTestCase
             'ZendTest\Module\TestAsset\MockApplication',
             'application',
         ]);
-            
+
         $this->application->setEventManager($appEvents);
     }
 

--- a/test/Listener/ServiceListenerTest.php
+++ b/test/Listener/ServiceListenerTest.php
@@ -11,8 +11,10 @@ namespace ZendTest\ModuleManager\Listener;
 
 use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
 use stdClass;
 use Zend\EventManager\EventManager;
+use Zend\EventManager\Test\EventListenerIntrospectionTrait;
 use Zend\ModuleManager\Exception;
 use Zend\ModuleManager\Feature\ServiceProviderInterface;
 use Zend\ModuleManager\Listener\ConfigListener;
@@ -20,14 +22,13 @@ use Zend\ModuleManager\Listener\ServiceListener;
 use Zend\ModuleManager\ModuleEvent;
 use Zend\ServiceManager\Config as ServiceConfig;
 use Zend\ServiceManager\ServiceManager;
-use ZendTest\ModuleManager\EventManagerIntrospectionTrait;
 
 /**
  * @covers Zend\ModuleManager\Listener\ServiceListener
  */
 class ServiceListenerTest extends TestCase
 {
-    use EventManagerIntrospectionTrait;
+    use EventListenerIntrospectionTrait;
 
     /**
      * @var ConfigListener
@@ -65,7 +66,8 @@ class ServiceListenerTest extends TestCase
     {
         $this->services = new ServiceManager();
         $this->listener = new ServiceListener($this->services);
-        $this->listener->setApplicationServiceManager(
+        $this->listener->addServiceManager(
+            $this->services,
             'service_manager',
             ServiceProviderInterface::class,
             'getServiceConfig'
@@ -74,24 +76,6 @@ class ServiceListenerTest extends TestCase
         $this->event          = new ModuleEvent();
         $this->configListener = new ConfigListener();
         $this->event->setConfigListener($this->configListener);
-    }
-
-    public function testPassingInvalidModuleDoesNothing()
-    {
-        $module = new stdClass();
-        $this->event->setModule($module);
-        $this->listener->onLoadModule($this->event);
-
-        $this->assertSame($this->services, $this->listener->getConfiguredServiceManager());
-    }
-
-    public function testInvalidReturnFromModuleDoesNothing()
-    {
-        $module = new TestAsset\ServiceInvalidReturnModule();
-        $this->event->setModule($module);
-        $this->listener->onLoadModule($this->event);
-
-        $this->assertSame($this->services, $this->listener->getConfiguredServiceManager());
     }
 
     public function getServiceConfig()
@@ -118,18 +102,70 @@ class ServiceListenerTest extends TestCase
         // @codingStandardsIgnoreEnd
     }
 
+    public function getConfiguredServiceManager($listener = null)
+    {
+        $listener = $listener ?: $this->listener;
+        $r = new ReflectionProperty($listener, 'defaultServiceManager');
+        $r->setAccessible(true);
+        return $r->getValue($listener);
+    }
+
     public function assertServiceManagerConfiguration()
     {
         $this->listener->onLoadModulesPost($this->event);
-        $services = $this->listener->getConfiguredServiceManager();
-        $this->assertNotSame($this->services, $services);
+        $services = $this->getConfiguredServiceManager();
+
         $this->assertInstanceOf(ServiceManager::class, $services);
+        $this->assertSame($this->services, $services);
 
         $this->assertTrue($services->has(__CLASS__));
         $this->assertTrue($services->has('foo'));
         $this->assertTrue($services->has('bar'));
-        $this->assertFalse($services->has('resolved-by-abstract'));
-        $this->assertTrue($services->has('resolved-by-abstract', true));
+        $this->assertTrue($services->has('resolved-by-abstract'));
+    }
+
+    public function assertServicesFromConfigArePresent(array $config, ServiceManager $serviceManager)
+    {
+        foreach ($config as $type => $services) {
+            switch ($type) {
+                case 'invokables':
+                    // fall through
+                case 'factories':
+                    // fall through
+                case 'aliases':
+                    foreach (array_keys($services) as $service) {
+                        $this->assertTrue(
+                            $serviceManager->has($service),
+                            sprintf(
+                                'Service manager is missing expected service %s',
+                                $service
+                            )
+                        );
+                    }
+                    break;
+                default:
+                    // Cannot test other types
+                    break;
+            }
+        }
+    }
+
+    public function testPassingInvalidModuleDoesNothing()
+    {
+        $module = new stdClass();
+        $this->event->setModule($module);
+        $this->listener->onLoadModule($this->event);
+
+        $this->assertSame($this->services, $this->getConfiguredServiceManager());
+    }
+
+    public function testInvalidReturnFromModuleDoesNothing()
+    {
+        $module = new TestAsset\ServiceInvalidReturnModule();
+        $this->event->setModule($module);
+        $this->listener->onLoadModule($this->event);
+
+        $this->assertSame($this->services, $this->getConfiguredServiceManager());
     }
 
     public function testModuleReturningArrayConfiguresServiceManager()
@@ -138,7 +174,7 @@ class ServiceListenerTest extends TestCase
         $module = new TestAsset\ServiceProviderModule($config);
         $this->event->setModule($module);
         $this->listener->onLoadModule($this->event);
-        $services = $this->listener->getConfiguredServiceManager();
+        $services = $this->getConfiguredServiceManager();
         $this->assertServiceManagerConfiguration();
     }
 
@@ -159,7 +195,8 @@ class ServiceListenerTest extends TestCase
             'baz' => new stdClass(),
         ]];
         $this->listener = new ServiceListener($this->services, $defaultConfig);
-        $this->listener->setApplicationServiceManager(
+        $this->listener->addServiceManager(
+            $this->services,
             'service_manager',
             ServiceProviderInterface::class,
             'getServiceConfig'
@@ -171,9 +208,7 @@ class ServiceListenerTest extends TestCase
         $this->listener->onLoadModule($this->event);
         $this->listener->onLoadModulesPost($this->event);
 
-        $services = $this->listener->getConfiguredServiceManager();
-        $this->assertNotSame($this->services, $services);
-        $this->assertTrue($services->has('config'));
+        $services = $this->getConfiguredServiceManager();
         $this->assertTrue($services->has('foo'));
         $this->assertNotSame($services->get('foo'), $services->get('bar'));
         $this->assertSame($services->get('foo'), $services->get('baz'));
@@ -218,7 +253,7 @@ class ServiceListenerTest extends TestCase
      */
     public function testUsingNonStringServiceManagerWithAddServiceManagerRaisesException($serviceManager)
     {
-        $this->setExpectedException(Exception\RuntimeException::class, 'expected string');
+        $this->setExpectedException(Exception\RuntimeException::class, 'expected ServiceManager or string');
         $this->listener->addServiceManager(
             $serviceManager,
             'service_manager',
@@ -227,26 +262,9 @@ class ServiceListenerTest extends TestCase
         );
     }
 
-    public function testAddingApplicationServiceManagerViaAddServiceManagerRaisesException()
-    {
-        $this->setExpectedException(Exception\RuntimeException::class, ServiceListener::IS_APP_MANAGER);
-        $this->listener->addServiceManager(
-            ServiceListener::IS_APP_MANAGER,
-            'service_manager',
-            ServiceProviderInterface::class,
-            'getServiceConfig'
-        );
-    }
-
     public function testCreatesPluginManagerBasedOnModuleImplementingSpecifiedProviderInterface()
     {
-        $received = [];
-        $services = $this->services->withConfig(['factories' => [
-            'CustomPluginManager' => function ($services, $name, array $options = null) use (&$received) {
-                $received = $options;
-                return new TestAsset\CustomPluginManager($services, $options);
-            }
-        ]]);
+        $services = $this->services->setFactory('CustomPluginManager', TestAsset\CustomPluginManagerFactory::class);
         $listener = new ServiceListener($services);
 
         $listener->addServiceManager(
@@ -261,24 +279,19 @@ class ServiceListenerTest extends TestCase
         $this->event->setModule($module);
         $listener->onLoadModule($this->event);
         $listener->onLoadModulesPost($this->event);
-        $this->assertEquals($pluginConfig, $received);
 
-        $configuredServices = $listener->getConfiguredServiceManager();
-        $this->assertNotSame($services, $configuredServices);
+        $configuredServices = $this->getConfiguredServiceManager($listener);
+        $this->assertSame($services, $configuredServices);
         $this->assertTrue($configuredServices->has('CustomPluginManager'));
         $plugins = $configuredServices->get('CustomPluginManager');
         $this->assertInstanceOf(TestAsset\CustomPluginManager::class, $plugins);
+
+        $this->assertServicesFromConfigArePresent($pluginConfig, $plugins);
     }
 
     public function testCreatesPluginManagerBasedOnModuleDuckTypingSpecifiedProviderInterface()
     {
-        $received = [];
-        $services = $this->services->withConfig(['factories' => [
-            'CustomPluginManager' => function ($services, $name, array $options = null) use (&$received) {
-                $received = $options;
-                return new TestAsset\CustomPluginManager($services, $options);
-            }
-        ]]);
+        $services = $this->services->setFactory('CustomPluginManager', TestAsset\CustomPluginManagerFactory::class);
         $listener = new ServiceListener($services);
 
         $listener->addServiceManager(
@@ -293,13 +306,14 @@ class ServiceListenerTest extends TestCase
         $this->event->setModule($module);
         $listener->onLoadModule($this->event);
         $listener->onLoadModulesPost($this->event);
-        $this->assertEquals($pluginConfig, $received);
 
-        $configuredServices = $listener->getConfiguredServiceManager();
-        $this->assertNotSame($services, $configuredServices);
+        $configuredServices = $this->getConfiguredServiceManager($listener);
+        $this->assertSame($services, $configuredServices);
         $this->assertTrue($configuredServices->has('CustomPluginManager'));
         $plugins = $configuredServices->get('CustomPluginManager');
         $this->assertInstanceOf(TestAsset\CustomPluginManager::class, $plugins);
+
+        $this->assertServicesFromConfigArePresent($pluginConfig, $plugins);
     }
 
     public function testAttachesListenersAtExpectedPriorities()

--- a/test/Listener/ServiceListenerTest.php
+++ b/test/Listener/ServiceListenerTest.php
@@ -264,7 +264,8 @@ class ServiceListenerTest extends TestCase
 
     public function testCreatesPluginManagerBasedOnModuleImplementingSpecifiedProviderInterface()
     {
-        $services = $this->services->setFactory('CustomPluginManager', TestAsset\CustomPluginManagerFactory::class);
+        $services = $this->services;
+        $services->setFactory('CustomPluginManager', TestAsset\CustomPluginManagerFactory::class);
         $listener = new ServiceListener($services);
 
         $listener->addServiceManager(
@@ -291,7 +292,8 @@ class ServiceListenerTest extends TestCase
 
     public function testCreatesPluginManagerBasedOnModuleDuckTypingSpecifiedProviderInterface()
     {
-        $services = $this->services->setFactory('CustomPluginManager', TestAsset\CustomPluginManagerFactory::class);
+        $services = $this->services;
+        $services->setFactory('CustomPluginManager', TestAsset\CustomPluginManagerFactory::class);
         $listener = new ServiceListener($services);
 
         $listener->addServiceManager(

--- a/test/Listener/TestAsset/CustomPluginManager.php
+++ b/test/Listener/TestAsset/CustomPluginManager.php
@@ -10,8 +10,21 @@
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 
 class CustomPluginManager extends AbstractPluginManager
 {
     protected $instanceOf = CustomPluginInterface::class;
+
+    public function validate($plugin)
+    {
+        if (! $plugin instanceof $this->instanceOf) {
+            throw new InvalidServiceException();
+        }
+    }
+
+    public function validatePlugin($plugin)
+    {
+        $this->validate($plugin);
+    }
 }

--- a/test/Listener/TestAsset/CustomPluginManagerFactory.php
+++ b/test/Listener/TestAsset/CustomPluginManagerFactory.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ModuleManager\Listener\TestAsset;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class CustomPluginManagerFactory implements FactoryInterface
+{
+    /**
+     * @var null|array
+     */
+    protected $creationOptions;
+
+    /**
+     * Create and return an instance of the CustomPluginManager (v3)
+     *
+     * @param ContainerInterface $container
+     * @param string $name
+     * @param null|array $options
+     * @return CustomPluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        $options = $options ?: [];
+        return new CustomPluginManager($container, $options);
+    }
+
+    /**
+     * Create and return an instance of the CustomPluginManager (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @return CustomPluginManager
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, CustomPluginManager::class, $this->creationOptions);
+    }
+
+    /**
+     * Provide options to use during instantiation (v2).
+     *
+     * @param array $options
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/test/Listener/TestAsset/SampleAbstractFactory.php
+++ b/test/Listener/TestAsset/SampleAbstractFactory.php
@@ -11,11 +11,17 @@ namespace ZendTest\ModuleManager\Listener\TestAsset;
 
 use Interop\Container\ContainerInterface;
 use stdClass;
-use Zend\ServiceManager\Factory\AbstractFactoryInterface;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class SampleAbstractFactory implements AbstractFactoryInterface
 {
-    public function canCreateServiceWithName(ContainerInterface $container, $name)
+    public function canCreate(ContainerInterface $container, $name)
+    {
+        return true;
+    }
+
+    public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
     {
         return true;
     }
@@ -23,5 +29,10 @@ class SampleAbstractFactory implements AbstractFactoryInterface
     public function __invoke(ContainerInterface $container, $name, array $options = [])
     {
         return new stdClass;
+    }
+
+    public function createServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
+    {
+        return $this($container, '');
     }
 }

--- a/test/TestAsset/ListenerTestModule/Module.php
+++ b/test/TestAsset/ListenerTestModule/Module.php
@@ -11,11 +11,13 @@ namespace ListenerTestModule;
 
 use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
 use Zend\ModuleManager\Feature\BootstrapListenerInterface;
+use Zend\ModuleManager\Feature\LocatorRegisteredInterface;
 use Zend\EventManager\EventInterface;
 
 class Module implements
     AutoloaderProviderInterface,
-    BootstrapListenerInterface
+    BootstrapListenerInterface,
+    LocatorRegisteredInterface
 {
     public $initCalled = false;
     public $getConfigCalled = false;


### PR DESCRIPTION
This patch removes the work done to make the component target only the v3 releases, as well as removes the changes to how service configuration was aggregated and injected. (These latter became unnecessary due to changes in zend-servicemanager.)

Among other things:

- Restores the `LocatorRegisteredInterface` and `LocatorRegistrationListener`. These were removed when we assumed we'd target v3, as zend-di integration can likely be assumed to be deprecated in that version. However, for a v2 release, we need to keep them for backwards compatibility.
- Restores the original workflow of `ServiceListener`, with some minor refactors (extract methods).
- Updates tests to use both backwards and forwards compatible syntax when working with service and event managers, ensuring tests will run in both versions.
- Adds a `CustomPluginManagerFactory` for creating the `CustomPluginManager` instance when testing, and adds a method for testing plugin managers received expected configuration.

All dependencies were updated to known stable, forwards compatible versions where available, and the test matrix was updated to test against both v2 and v3 versions of zend-eventmanager and zend-servicemanager, on all PHP versions supported.

This patch allows the develop branch to once again target a 2.X release, specifically 2.7.