### PR TITLE
Ensure LocatorRegistrationListener is registered by default

### DIFF
--- a/src/Listener/DefaultListenerAggregate.php
+++ b/src/Listener/DefaultListenerAggregate.php
@@ -40,6 +40,7 @@ class DefaultListenerAggregate extends AbstractListener implements
     {
         $options                     = $this->getOptions();
         $configListener              = $this->getConfigListener();
+        $locatorRegistrationListener = new LocatorRegistrationListener($options);
         $moduleLoaderListener        = new ModuleLoaderListener($options);
 
         // High priority, we assume module autoloading (for FooNamespace\Module
@@ -59,7 +60,9 @@ class DefaultListenerAggregate extends AbstractListener implements
         $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, new InitTrigger($options));
         $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, new OnBootstrapListener($options));
 
+        $locatorRegistrationListener->attach($events);
         $configListener->attach($events);
+        $this->listeners[] = $locatorRegistrationListener;
         $this->listeners[] = $configListener;
         return $this;
     }

--- a/src/Listener/LocatorRegistrationListener.php
+++ b/src/Listener/LocatorRegistrationListener.php
@@ -11,6 +11,7 @@ namespace Zend\ModuleManager\Listener;
 
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
+use Zend\EventManager\ListenerAggregateTrait;
 use Zend\ModuleManager\Feature\LocatorRegisteredInterface;
 use Zend\ModuleManager\ModuleEvent;
 use Zend\ModuleManager\ModuleManager;
@@ -22,15 +23,12 @@ use Zend\Mvc\MvcEvent;
 class LocatorRegistrationListener extends AbstractListener implements
     ListenerAggregateInterface
 {
-    /**
-     * @var array
-     */
-    protected $modules = [];
+    use ListenerAggregateTrait;
 
     /**
      * @var array
      */
-    protected $callbacks = [];
+    protected $modules = [];
 
     /**
      * loadModule
@@ -113,22 +111,10 @@ class LocatorRegistrationListener extends AbstractListener implements
     /**
      * {@inheritDoc}
      */
-    public function attach(EventManagerInterface $events)
+    public function attach(EventManagerInterface $events, $priority = 1)
     {
-        $this->callbacks[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, [$this, 'onLoadModule']);
-        $this->callbacks[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES, [$this, 'onLoadModules'], -1000);
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULE, [$this, 'onLoadModule']);
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES, [$this, 'onLoadModules'], -1000);
         return $this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function detach(EventManagerInterface $events)
-    {
-        foreach ($this->callbacks as $index => $callback) {
-            if ($events->detach($callback)) {
-                unset($this->callbacks[$index]);
-            }
-        }
     }
 }

--- a/test/Listener/DefaultListenerAggregateTest.php
+++ b/test/Listener/DefaultListenerAggregateTest.php
@@ -49,6 +49,7 @@ class DefaultListenerAggregateTest extends AbstractListenerTestCase
                 'Zend\Loader\ModuleAutoloader',
                 'config-pre' => 'Zend\ModuleManager\Listener\ConfigListener',
                 'config-post' => 'Zend\ModuleManager\Listener\ConfigListener',
+                'Zend\ModuleManager\Listener\LocatorRegistrationListener',
                 'Zend\ModuleManager\ModuleManager',
             ],
             'loadModule.resolve' => [
@@ -60,6 +61,7 @@ class DefaultListenerAggregateTest extends AbstractListenerTestCase
                 'Zend\ModuleManager\Listener\InitTrigger',
                 'Zend\ModuleManager\Listener\OnBootstrapListener',
                 'Zend\ModuleManager\Listener\ConfigListener',
+                'Zend\ModuleManager\Listener\LocatorRegistrationListener',
             ],
         ];
         foreach ($expectedEvents as $event => $expectedListeners) {


### PR DESCRIPTION
PR #13 initially removed the LocatorRegistrationListener, and #28 re-added it. However, the listener was still removed from the set of default listeners. This patch fixes that, to ensure backwards compatibility.