### PR TITLE
The ServiceListener needs to be able to overwrite existing configuration

### DIFF
--- a/src/Listener/ServiceListener.php
+++ b/src/Listener/ServiceListener.php
@@ -217,7 +217,15 @@ class ServiceListener implements ServiceListenerInterface
             }
 
             $serviceConfig = new ServiceConfig($smConfig);
+
+            // The service listener is meant to operate during bootstrap, and, as such,
+            // needs to be able to override existing configuration.
+            $allowOverride = $sm['service_manager']->getAllowOverride();
+            $sm['service_manager']->setAllowOverride(true);
+
             $serviceConfig->configureServiceManager($sm['service_manager']);
+
+            $sm['service_manager']->setAllowOverride($allowOverride);
         }
     }
 


### PR DESCRIPTION
In testing zend-mvc for forwards compatibility, I ran into an issue with the ServiceListener: if a service was already configured when the ServiceListener ran, an exception was thrown due to being unable to overwrite services. This should always be allowed in the ServiceListener.