### PR TITLE
remove uneeded AutoloaderFactory::unregisterAutoloaders()

### DIFF
--- a/test/ResetAutoloadFunctionsTrait.php
+++ b/test/ResetAutoloadFunctionsTrait.php
@@ -9,8 +9,6 @@
 
 namespace ZendTest\ModuleManager;
 
-use Zend\Loader\AutoloaderFactory;
-
 /**
  * Offer common setUp/tearDown methods for preserve current autoload functions and include paths.
  */
@@ -52,7 +50,6 @@ trait ResetAutoloadFunctionsTrait
      */
     protected function restoreAutoloadFunctions()
     {
-        AutoloaderFactory::unregisterAutoloaders();
         $loaders = spl_autoload_functions();
         if (is_array($loaders)) {
             foreach ($loaders as $loader) {


### PR DESCRIPTION
This is no more needed.

In 2.6, as all registered autloaders were unregistered / registered again, this works.

In 2.7, only added autoloaders are unregistered, so this is not needed anymore

More, if default autoloader is Zend one (instead of composer one), this break, all the test suite.

     PHP Fatal error:  Class 'Zend\ModuleManager\Listener\ConfigListener' not found in


