### PR TITLE
Re-enable tests against zend-mvc on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
   global:
     - EVENT_MANAGER_VERSION="^3.0"
     - SERVICE_MANAGER_VERSION="^3.0.3"
-    - REMOVE_DEPS="zendframework/zend-mvc"
 
 matrix:
   fast_finish: true
@@ -27,7 +26,6 @@ matrix:
       env:
         - EVENT_MANAGER_VERSION="^2.6.2"
         - SERVICE_MANAGER_VERSION="^2.7.5"
-        - REMOVE_DEPS=""
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
@@ -35,19 +33,16 @@ matrix:
       env:
         - EVENT_MANAGER_VERSION="^2.6.2"
         - SERVICE_MANAGER_VERSION="^2.7.5"
-        - REMOVE_DEPS=""
     - php: 7
     - php: 7
       env:
         - EVENT_MANAGER_VERSION="^2.6.2"
         - SERVICE_MANAGER_VERSION="^2.7.5"
-        - REMOVE_DEPS=""
     - php: hhvm 
     - php: hhvm 
       env:
         - EVENT_MANAGER_VERSION="^2.6.2"
         - SERVICE_MANAGER_VERSION="^2.7.5"
-        - REMOVE_DEPS=""
   allow_failures:
     - php: hhvm
 
@@ -61,7 +56,6 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - composer require --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION"
   - composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION"
-  - if [[ $REMOVE_DEPS != '' ]]; then composer remove --dev --no-update $REMOVE_DEPS ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "zendframework/zend-console": "^2.6",
         "zendframework/zend-di": "^2.6",
         "zendframework/zend-loader": "^2.5",
+        "zendframework/zend-mvc": "^2.7",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"


### PR DESCRIPTION
Now that zend-mvc has a known-stable, forwards-compatible version, we can re-enable tests against it on Travis.

In this particular case, because the tests were disabled when testing against zend-servicemanager v3, tests also needed to be updated to run correctly against zend-eventmanager v3.