### PR TITLE
Do not raise an exception if a given plugin manager is not defined.

### DIFF
--- a/src/Listener/ServiceListener.php
+++ b/src/Listener/ServiceListener.php
@@ -199,10 +199,8 @@ class ServiceListener implements ServiceListenerInterface
 
             if (! $sm['service_manager'] instanceof ServiceManager) {
                 if (! $this->defaultServiceManager->has($sm['service_manager'])) {
-                    throw new Exception\RuntimeException(sprintf(
-                        'Could not find a valid ServiceManager for %s',
-                        $sm['service_manager']
-                    ));
+                    // No plugin manager registered by that name; nothing to configure.
+                    continue;
                 }
 
                 $instance = $this->defaultServiceManager->get($sm['service_manager']);

--- a/test/Listener/TestAsset/UndefinedProviderInterface.php
+++ b/test/Listener/TestAsset/UndefinedProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\ModuleManager\Listener\TestAsset;
+
+interface UndefinedProviderInterface
+{
+    public function getUndefinedConfig();
+}


### PR DESCRIPTION
The `ServiceListener::onLoadModulesPost()` listener raises an exception if a given plugin manager instance is unavailable, and does not exist in the application service manager. This impacts migrating the various plugin managers to their respective components:
- If they are registered as part of the module configuration, but that component is not present, then an exception is raised.
- We cannot add delegator factories on the `ServiceListener` from component module classes, as the `ServiceListener` is retrieved _before_ loading modules.

One solution is to assume that if the plugin manager is not present, nothing needs to be done. This allows components to map the plugin loader services they expose via their `Module` classes, ensuring that once the listener triggers, it _can_ access the service and configure it.

Incidentally, there is also a solution to components notifying the `ServiceListener` of plugin manager specifications already, via the `init()` method. As an example:

``` php
namespace Some\Component;

class Module
{
    public function init($event)
    {
        $container = $event->getParam('ServiceManager');
        $serviceListener = $container->get('ServiceListener');
        $serviceListener->addServiceManager(/* ... */);
    }
}
```

As components are expected to be listed early in the module list, this approach should be robust enough to ensure userland and third party _modules_ (not _components_) registered later can configure the plugin manager.

The patch submitted ensures that in the off chance that a plugin manager is registered but has no service associated with it, exceptions need not be thrown.
