### PR TITLE
Fix config overriding and partial read in high request rate applications

### DIFF
--- a/src/Listener/AbstractListener.php
+++ b/src/Listener/AbstractListener.php
@@ -62,7 +62,7 @@ abstract class AbstractListener
     protected function writeArrayToFile($filePath, $array)
     {
         $content = "<?php\nreturn " . var_export($array, 1) . ';';
-        file_put_contents($filePath, $content);
+        file_put_contents($filePath, $content, LOCK_EX);
         return $this;
     }
 }


### PR DESCRIPTION
In a high request rate application there's situation right after deploy when the first request is writing to the file but another request is trying to read the same. As result the second request fails with syntax error:

```
[FATAL] file:20160516150437/data/cache/module-config-cache.cli.tt.config.php | ln:6043 | msg:syntax error, unexpected ''XXX\Yy' (T_ENCAPSED_AND_WHITESPACE)
```
