### PR TITLE
Added zend-config as a requirement (vs dev-only)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
+        "zendframework/zend-config": "^2.6",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-config": "^2.6",
         "zendframework/zend-console": "^2.6",
         "zendframework/zend-di": "^2.6",
         "zendframework/zend-loader": "^2.5",


### PR DESCRIPTION
Per zendframework/ZendSkeletonApplication#329, the default usage pattern for zend-modulemanager does configuration merging, which, at this time, requires zend-config. If this is not present in zend-modulemanager, any application using the default listeners will need to add the requirement manually in order to work (which is precisely what happened with the aforementioned PR).