### PR TITLE
Remove `permission denied` warning if unable write config to cache

### DIFF
--- a/src/Listener/AbstractListener.php
+++ b/src/Listener/AbstractListener.php
@@ -61,8 +61,11 @@ abstract class AbstractListener
      */
     protected function writeArrayToFile($filePath, $array)
     {
-        $content = "<?php\nreturn " . var_export($array, 1) . ';';
-        file_put_contents($filePath, $content);
+        if (is_writable(dirname($filePath))) {
+            $content = "<?php\nreturn " . var_export($array, 1) . ';';
+            file_put_contents($filePath, $content);
+        }
+
         return $this;
     }
 }


### PR DESCRIPTION
Remove warning "Warning: file_put_contents(data/cache/module-config-cache.application.config.cache.php): failed to open stream: Permission denied in ...".
