### PR TITLE
ModuleManager load module childs dependentsLoad childs modules

### DIFF
--- a/test/Listener/ConfigListenerTest.php
+++ b/test/Listener/ConfigListenerTest.php
@@ -346,12 +346,12 @@ class ConfigListenerTest extends AbstractListenerTestCase
 
         $moduleManager = $this->moduleManager;
         $events        = $moduleManager->getEventManager();
-        $this->assertEquals(2, count($this->getEventsFromEventManager($events)));
+        $this->assertEquals(3, count($this->getEventsFromEventManager($events)));
 
         $configListener->attach($events);
         $this->assertEquals(4, count($this->getEventsFromEventManager($events)));
 
         $configListener->detach($events);
-        $this->assertEquals(2, count($this->getEventsFromEventManager($events)));
+        $this->assertEquals(3, count($this->getEventsFromEventManager($events)));
     }
 }

--- a/test/Listener/DefaultListenerAggregateTest.php
+++ b/test/Listener/DefaultListenerAggregateTest.php
@@ -62,6 +62,7 @@ class DefaultListenerAggregateTest extends AbstractListenerTestCase
                 'Zend\ModuleManager\Listener\OnBootstrapListener',
                 'Zend\ModuleManager\Listener\ConfigListener',
                 'Zend\ModuleManager\Listener\LocatorRegistrationListener',
+                'Zend\ModuleManager\ModuleManager',
             ],
         ];
         foreach ($expectedEvents as $event => $expectedListeners) {
@@ -86,12 +87,12 @@ class DefaultListenerAggregateTest extends AbstractListenerTestCase
         $moduleManager     = new ModuleManager(['ListenerTestModule']);
         $events            = $moduleManager->getEventManager();
 
-        $this->assertEquals(1, count($this->getEventsFromEventManager($events)));
+        $this->assertEquals(2, count($this->getEventsFromEventManager($events)));
 
         $listenerAggregate->attach($events);
         $this->assertEquals(4, count($this->getEventsFromEventManager($events)));
 
         $listenerAggregate->detach($events);
-        $this->assertEquals(1, count($this->getEventsFromEventManager($events)));
+        $this->assertEquals(2, count($this->getEventsFromEventManager($events)));
     }
 }

--- a/test/ModuleManagerTest.php
+++ b/test/ModuleManagerTest.php
@@ -233,4 +233,21 @@ class ModuleManagerTest extends TestCase
         $this->assertInstanceOf(ModuleEvent::class, $event);
         $this->assertSame($moduleManager, $event->getTarget());
     }
+
+    public function testLoadChildsModules()
+    {
+        $moduleManager  = new ModuleManager(['LoadChildsModule'], $this->events);
+        $this->defaultListeners->attach($this->events);
+        $moduleManager->loadModules();
+
+        $this->assertSame(
+            ['LoadChildsModule', 'LoadChildsModule2', 'BarModule', 'SomeModule'],
+            array_keys($moduleManager->getLoadedModules())
+        );
+
+        $this->assertArraySubset(
+            ['bar' => 'foo', 'some' => 'thing'],
+            $this->defaultListeners->getConfigListener()->getMergedConfig(false)
+        );
+    }
 }

--- a/test/TestAsset/LoadChildsModule/Module.php
+++ b/test/TestAsset/LoadChildsModule/Module.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace LoadChildsModule;
+
+
+class Module
+{
+    public function init($moduleManager)
+    {
+        $moduleManager->loadModule('LoadChildsModule2', 'after');
+        $moduleManager->loadModule(['SomeModule' => new \SomeModule\Module()], 'after');
+    }
+
+    public function getConfig()
+    {
+        return [
+            'bar' => 'SubModule',
+        ];
+    }
+}

--- a/test/TestAsset/LoadChildsModule2/Module.php
+++ b/test/TestAsset/LoadChildsModule2/Module.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace LoadChildsModule2;
+
+
+class Module
+{
+    public function init($moduleManager)
+    {
+        $moduleManager->loadModule('BarModule', 'after');
+    }
+
+    public function getConfig()
+    {
+        return [
+            'bar' => 'SubModule',
+        ];
+    }
+}

--- a/test/TestAsset/LoadChildsModule2/configs/config-c832f68.php
+++ b/test/TestAsset/LoadChildsModule2/configs/config-c832f68.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'some' => 'thing',
+];


### PR DESCRIPTION
Allow load modules (from Module::init()) after current module.
Analog of https://github.com/zendframework/zendframework/pull/5651, but:
load modules A, B - configs order is A, B.
load modules A -> B - configs order is A, B.

recreated from https://github.com/zendframework/zend-modulemanager/issues/47