### PR TITLE
Prevent race condition on writing cache files

### DIFF
--- a/src/Listener/AbstractListener.php
+++ b/src/Listener/AbstractListener.php
@@ -62,7 +62,7 @@ abstract class AbstractListener
     protected function writeArrayToFile($filePath, $array)
     {
         $content = "<?php\nreturn " . var_export($array, 1) . ';';
-        file_put_contents($filePath, $content);
+        file_put_contents($filePath, $content, LOCK_EX);
         return $this;
     }
 }


### PR DESCRIPTION
When multiple people first access a ZF2 powered website there is the possibility that both requests write simultaneously write a slightly different file to disk. The result can be an PHP file having a parse error.

I encountered this problem on a production website. Because the configuration contains an syntax error the whole website was down. In order to restore this I needed to throw away the generated config file and *hope* that a valid one would appear.

This commit fixes this by acquiring an exclusive lock.