### PR TITLE
fix proto and enable php 7.1 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,11 @@ matrix:
       env:
         - EVENT_MANAGER_VERSION="^2.6.2"
         - SERVICE_MANAGER_VERSION="^2.7.5"
+    - php: 7.1
+    - php: 7.1
+      env:
+        - EVENT_MANAGER_VERSION="^2.6.2"
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: hhvm 
     - php: hhvm 
       env:

--- a/test/Listener/TestAsset/SampleAbstractFactory.php
+++ b/test/Listener/TestAsset/SampleAbstractFactory.php
@@ -26,7 +26,7 @@ class SampleAbstractFactory implements AbstractFactoryInterface
         return true;
     }
 
-    public function __invoke(ContainerInterface $container, $name, array $options = [])
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
         return new stdClass;
     }


### PR DESCRIPTION
```
PHPUnit 5.7.13 by Sebastian Bergmann and contributors.
.................................WWW.......PHP Fatal error:  Declaration of ZendTest\ModuleManager\Listener\TestAsset\SampleAbstractFactory::__invoke(Interop\Container\ContainerInterface $container, $name, array $options = Array) must be compatible with Zend\ServiceManager\Factory\FactoryInterface::__invoke(Interop\Container\ContainerInterface $container, $requestedName, ?array $options = NULL) in /builddir/build
```