### PR TITLE
Test for a `Module` class before testing for a class named after the module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,12 @@
     },
     "autoload-dev": {
         "files": [
-            "test/autoload.php"
+            "test/autoload.php",
+            "test/TestAsset/ModuleAsClass.php"
         ],
         "psr-4": {
             "ListenerTestModule\\": "test/TestAsset/ListenerTestModule/",
+            "ModuleAsClass\\": "test/TestAsset/ModuleAsClass/",
             "ZendTest\\ModuleManager\\": "test/"
         }
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,4 +5,9 @@
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+
+    <!-- Exclusions -->
+    <rule ref="PSR1.Classes.ClassDeclaration">
+        <exclude-pattern>*/test/TestAsset/ModuleAsClass.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/Listener/ModuleResolverListener.php
+++ b/src/Listener/ModuleResolverListener.php
@@ -9,6 +9,7 @@
 
 namespace Zend\ModuleManager\Listener;
 
+use Generator;
 use Zend\ModuleManager\ModuleEvent;
 
 /**
@@ -17,6 +18,15 @@ use Zend\ModuleManager\ModuleEvent;
 class ModuleResolverListener extends AbstractListener
 {
     /**
+     * Class names that are invalid as module classes, due to inability to instantiate.
+     *
+     * @var string[]
+     */
+    protected $invalidClassNames = [
+        Generator::class,
+    ];
+
+    /**
      * @param  ModuleEvent $e
      * @return object|false False if module class does not exist
      */
@@ -24,16 +34,17 @@ class ModuleResolverListener extends AbstractListener
     {
         $moduleName = $e->getModuleName();
 
-        if (class_exists($moduleName)) {
+        $class = sprintf('%s\Module', $moduleName);
+        if (class_exists($class)) {
+            return new $class;
+        }
+
+        if (class_exists($moduleName)
+            && ! in_array($moduleName, $this->invalidClassNames, true)
+        ) {
             return new $moduleName;
         }
 
-        $class      = $moduleName . '\Module';
-
-        if (! class_exists($class)) {
-            return false;
-        }
-
-        return new $class;
+        return false;
     }
 }

--- a/test/Listener/ModuleResolverListenerTest.php
+++ b/test/Listener/ModuleResolverListenerTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\ModuleManager\Listener;
 
 use ListenerTestModule;
+use ModuleAsClass;
 use Zend\ModuleManager\Listener\ModuleResolverListener;
 use Zend\ModuleManager\ModuleEvent;
 
@@ -47,6 +48,24 @@ class ModuleResolverListenerTest extends AbstractListenerTestCase
         $e = new ModuleEvent;
 
         $e->setModuleName('DoesNotExist');
+        $this->assertFalse($moduleResolver($e));
+    }
+
+    public function testModuleResolverListenerPrefersModuleClassesInModuleNamespaceOverNamedClasses()
+    {
+        $moduleResolver = new ModuleResolverListener;
+        $e = new ModuleEvent;
+
+        $e->setModuleName('ModuleAsClass');
+        $this->assertInstanceOf(ModuleAsClass\Module::class, $moduleResolver($e));
+    }
+
+    public function testModuleResolverListenerWillNotAttemptToResolveModuleAsClassNameGenerator()
+    {
+        $moduleResolver = new ModuleResolverListener;
+        $e = new ModuleEvent;
+
+        $e->setModuleName('Generator');
         $this->assertFalse($moduleResolver($e));
     }
 }

--- a/test/TestAsset/ModuleAsClass.php
+++ b/test/TestAsset/ModuleAsClass.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
+class ModuleAsClass
+{
+}

--- a/test/TestAsset/ModuleAsClass/Module.php
+++ b/test/TestAsset/ModuleAsClass/Module.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ModuleAsClass;
+
+class Module
+{
+}


### PR DESCRIPTION
Per #72, non-namespaced classes can create issues within applications if
they conflict with a module. In particular, `Generator` is one (as the
class is non-instantiable via `new`), but this can also happen in legacy
applications where a new module may exist under the same name as a
defined class.

This patch adds tests to ensure that the resolver prefers `Module`
classes if they exist, and never loads known uninstantiable classes that
always exist (specifically, `Generator`).

Fixes #72