### PR TITLE
Make PHPdoc2 `@method` tag parseable

### DIFF
--- a/src/ModuleEvent.php
+++ b/src/ModuleEvent.php
@@ -15,7 +15,7 @@ use Zend\EventManager\Event;
  * Custom event for use with module manager
  * Composes Module objects
  *
- * @method ModuleManager getTarget
+ * @method ModuleManager getTarget()
  */
 class ModuleEvent extends Event
 {


### PR DESCRIPTION
https://docs.phpdoc.org/references/phpdoc/tags/method.html seems to say that brackets are mandatory

> `    @method [return type] [name]([[type] [parameter]<, …>]) [<description>]`

I'm assuming there's no Reflection extracting the comments from ModuleEvent in zendframework. Is that correct?

A quick look at uses of getTarget suggests there are 0 params.