### PR TITLE
Bump minimum php to 7.1 and bump next version to major

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,6 @@ env:
 
 matrix:
   include:
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit zendframework/zend-code"
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit zendframework/zend-code"
-    - php: 7
-      env:
-        - DEPS=latest
     - php: 7.1
       env:
         - DEPS=lowest
@@ -58,8 +38,7 @@ before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
+  - travis_retry composer install $COMPOSER_ARGS
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 2.9.0 - TBD
+## 3.0.0 - TBD
 
 ### Added
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "forum": "https://discourse.zendframework.com/c/questions/components"
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "zendframework/zend-config": "^3.1 || ^2.6",
         "zendframework/zend-eventmanager": "^3.2 || ^2.6.3",
         "zendframework/zend-stdlib": "^3.1 || ^2.7"

--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev",
-            "dev-develop": "2.8-dev"
+            "dev-master": "2.8-dev",
+            "dev-develop": "3.0-dev"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "zendframework/zend-loader": "^2.5",
         "zendframework/zend-mvc": "^3.0 || ^2.7",
         "zendframework/zend-servicemanager": "^3.0.3 || ^2.7.5",
-        "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+        "phpunit/phpunit": "^6.5.2",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "24e16fadbe358284877d567d3ba8aeff",
+    "content-hash": "1ed45f6aab38dac4daed0a654327ede1",
     "packages": [
         {
             "name": "psr/container",
@@ -2107,37 +2107,39 @@
         },
         {
             "name": "zendframework/zend-mvc",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-mvc.git",
-                "reference": "ba40f2c795403ce8b95f9251657cc2b96c40c417"
+                "reference": "236e7e1e3757e988fa06530c0a3f96a148858ae8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-mvc/zipball/ba40f2c795403ce8b95f9251657cc2b96c40c417",
-                "reference": "ba40f2c795403ce8b95f9251657cc2b96c40c417",
+                "url": "https://api.github.com/repos/zendframework/zend-mvc/zipball/236e7e1e3757e988fa06530c0a3f96a148858ae8",
+                "reference": "236e7e1e3757e988fa06530c0a3f96a148858ae8",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.1",
+                "container-interop/container-interop": "^1.2",
                 "php": "^5.6 || ^7.0",
-                "zendframework/zend-eventmanager": "^3.0",
-                "zendframework/zend-http": "^2.5.4",
-                "zendframework/zend-modulemanager": "^2.7.1",
-                "zendframework/zend-router": "^3.0.1",
-                "zendframework/zend-servicemanager": "^3.0.3",
-                "zendframework/zend-stdlib": "^3.0",
-                "zendframework/zend-view": "^2.6.7"
+                "zendframework/zend-eventmanager": "^3.2",
+                "zendframework/zend-http": "^2.7",
+                "zendframework/zend-modulemanager": "^2.8",
+                "zendframework/zend-router": "^3.0.2",
+                "zendframework/zend-servicemanager": "^3.3",
+                "zendframework/zend-stdlib": "^3.1",
+                "zendframework/zend-view": "^2.9"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0.7 || ^5.7.14",
+                "http-interop/http-middleware": "^0.4.1",
+                "phpunit/phpunit": "^6.4.4 || ^5.7.14",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-json": "^2.6.1 || ^3.0",
-                "zendframework/zend-psr7bridge": "^0.2",
+                "zendframework/zend-psr7bridge": "^1.0",
                 "zendframework/zend-stratigility": "^2.0.1"
             },
             "suggest": {
+                "http-interop/http-middleware": "^0.4.1 to be used together with zend-stratigility",
                 "zendframework/zend-json": "(^2.6.1 || ^3.0) To auto-deserialize JSON body content in AbstractRestfulController extensions, when json_decode is unavailable",
                 "zendframework/zend-log": "^2.9.1  To provide log functionality via LogFilterManager, LogFormatterManager, and LogProcessorManager",
                 "zendframework/zend-mvc-console": "zend-mvc-console provides the ability to expose zend-mvc as a console application",
@@ -2167,12 +2169,13 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-mvc",
+            "description": "Zend Framework's event-driven MVC layer, including MVC Applications, Controllers, and Plugins",
             "keywords": [
+                "ZendFramework",
                 "mvc",
-                "zf2"
+                "zf"
             ],
-            "time": "2017-05-01T20:21:57+00:00"
+            "time": "2017-11-24T06:32:07+00:00"
         },
         {
             "name": "zendframework/zend-router",
@@ -2510,7 +2513,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ed45f6aab38dac4daed0a654327ede1",
+    "content-hash": "92dd2253752c84c06f239fddc91ba697",
     "packages": [
         {
             "name": "psr/container",

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Exception;
 

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Exception;

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Exception;
 

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Exception;

--- a/src/Exception/MissingDependencyModuleException.php
+++ b/src/Exception/MissingDependencyModuleException.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Exception;
 

--- a/src/Exception/MissingDependencyModuleException.php
+++ b/src/Exception/MissingDependencyModuleException.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Exception;

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Exception;
 

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Exception;

--- a/src/Feature/AutoloaderProviderInterface.php
+++ b/src/Feature/AutoloaderProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/AutoloaderProviderInterface.php
+++ b/src/Feature/AutoloaderProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/BootstrapListenerInterface.php
+++ b/src/Feature/BootstrapListenerInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/BootstrapListenerInterface.php
+++ b/src/Feature/BootstrapListenerInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/ConfigProviderInterface.php
+++ b/src/Feature/ConfigProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/ConfigProviderInterface.php
+++ b/src/Feature/ConfigProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/ConsoleBannerProviderInterface.php
+++ b/src/Feature/ConsoleBannerProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/ConsoleBannerProviderInterface.php
+++ b/src/Feature/ConsoleBannerProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/ConsoleUsageProviderInterface.php
+++ b/src/Feature/ConsoleUsageProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/ConsoleUsageProviderInterface.php
+++ b/src/Feature/ConsoleUsageProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/ControllerPluginProviderInterface.php
+++ b/src/Feature/ControllerPluginProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/ControllerPluginProviderInterface.php
+++ b/src/Feature/ControllerPluginProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/ControllerProviderInterface.php
+++ b/src/Feature/ControllerProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/ControllerProviderInterface.php
+++ b/src/Feature/ControllerProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/DependencyIndicatorInterface.php
+++ b/src/Feature/DependencyIndicatorInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/DependencyIndicatorInterface.php
+++ b/src/Feature/DependencyIndicatorInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/FilterProviderInterface.php
+++ b/src/Feature/FilterProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/FilterProviderInterface.php
+++ b/src/Feature/FilterProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/FormElementProviderInterface.php
+++ b/src/Feature/FormElementProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/FormElementProviderInterface.php
+++ b/src/Feature/FormElementProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/HydratorProviderInterface.php
+++ b/src/Feature/HydratorProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/HydratorProviderInterface.php
+++ b/src/Feature/HydratorProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/InitProviderInterface.php
+++ b/src/Feature/InitProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/InitProviderInterface.php
+++ b/src/Feature/InitProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/InputFilterProviderInterface.php
+++ b/src/Feature/InputFilterProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/InputFilterProviderInterface.php
+++ b/src/Feature/InputFilterProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/LocatorRegisteredInterface.php
+++ b/src/Feature/LocatorRegisteredInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/LocatorRegisteredInterface.php
+++ b/src/Feature/LocatorRegisteredInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/LogProcessorProviderInterface.php
+++ b/src/Feature/LogProcessorProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/LogProcessorProviderInterface.php
+++ b/src/Feature/LogProcessorProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/LogWriterProviderInterface.php
+++ b/src/Feature/LogWriterProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/LogWriterProviderInterface.php
+++ b/src/Feature/LogWriterProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/RouteProviderInterface.php
+++ b/src/Feature/RouteProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/RouteProviderInterface.php
+++ b/src/Feature/RouteProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/SerializerProviderInterface.php
+++ b/src/Feature/SerializerProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/SerializerProviderInterface.php
+++ b/src/Feature/SerializerProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/ServiceProviderInterface.php
+++ b/src/Feature/ServiceProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/ServiceProviderInterface.php
+++ b/src/Feature/ServiceProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/TranslatorPluginProviderInterface.php
+++ b/src/Feature/TranslatorPluginProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/TranslatorPluginProviderInterface.php
+++ b/src/Feature/TranslatorPluginProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/ValidatorProviderInterface.php
+++ b/src/Feature/ValidatorProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/ValidatorProviderInterface.php
+++ b/src/Feature/ValidatorProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Feature/ViewHelperProviderInterface.php
+++ b/src/Feature/ViewHelperProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Feature;

--- a/src/Feature/ViewHelperProviderInterface.php
+++ b/src/Feature/ViewHelperProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Feature;
 

--- a/src/Listener/AbstractListener.php
+++ b/src/Listener/AbstractListener.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 
@@ -59,7 +60,7 @@ abstract class AbstractListener
      */
     protected function writeArrayToFile($filePath, $array)
     {
-        $content = "<?php\nreturn " . var_export($array, 1) . ';';
+        $content = "<?php\nreturn " . var_export($array, true) . ';';
         file_put_contents($filePath, $content, LOCK_EX);
         return $this;
     }

--- a/src/Listener/AbstractListener.php
+++ b/src/Listener/AbstractListener.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/AutoloaderListener.php
+++ b/src/Listener/AutoloaderListener.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/AutoloaderListener.php
+++ b/src/Listener/AutoloaderListener.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/ConfigListener.php
+++ b/src/Listener/ConfigListener.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/ConfigListener.php
+++ b/src/Listener/ConfigListener.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/ConfigMergerInterface.php
+++ b/src/Listener/ConfigMergerInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/ConfigMergerInterface.php
+++ b/src/Listener/ConfigMergerInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/DefaultListenerAggregate.php
+++ b/src/Listener/DefaultListenerAggregate.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/DefaultListenerAggregate.php
+++ b/src/Listener/DefaultListenerAggregate.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/Exception/ExceptionInterface.php
+++ b/src/Listener/Exception/ExceptionInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener\Exception;

--- a/src/Listener/Exception/ExceptionInterface.php
+++ b/src/Listener/Exception/ExceptionInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener\Exception;
 

--- a/src/Listener/Exception/InvalidArgumentException.php
+++ b/src/Listener/Exception/InvalidArgumentException.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener\Exception;

--- a/src/Listener/Exception/InvalidArgumentException.php
+++ b/src/Listener/Exception/InvalidArgumentException.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener\Exception;
 

--- a/src/Listener/Exception/RuntimeException.php
+++ b/src/Listener/Exception/RuntimeException.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener\Exception;

--- a/src/Listener/Exception/RuntimeException.php
+++ b/src/Listener/Exception/RuntimeException.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener\Exception;
 

--- a/src/Listener/InitTrigger.php
+++ b/src/Listener/InitTrigger.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/InitTrigger.php
+++ b/src/Listener/InitTrigger.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/ListenerOptions.php
+++ b/src/Listener/ListenerOptions.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/ListenerOptions.php
+++ b/src/Listener/ListenerOptions.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/LocatorRegistrationListener.php
+++ b/src/Listener/LocatorRegistrationListener.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/LocatorRegistrationListener.php
+++ b/src/Listener/LocatorRegistrationListener.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/ModuleDependencyCheckerListener.php
+++ b/src/Listener/ModuleDependencyCheckerListener.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/ModuleDependencyCheckerListener.php
+++ b/src/Listener/ModuleDependencyCheckerListener.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/ModuleLoaderListener.php
+++ b/src/Listener/ModuleLoaderListener.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/ModuleLoaderListener.php
+++ b/src/Listener/ModuleLoaderListener.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/ModuleResolverListener.php
+++ b/src/Listener/ModuleResolverListener.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/ModuleResolverListener.php
+++ b/src/Listener/ModuleResolverListener.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/OnBootstrapListener.php
+++ b/src/Listener/OnBootstrapListener.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/OnBootstrapListener.php
+++ b/src/Listener/OnBootstrapListener.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/ServiceListener.php
+++ b/src/Listener/ServiceListener.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/ServiceListener.php
+++ b/src/Listener/ServiceListener.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/Listener/ServiceListenerInterface.php
+++ b/src/Listener/ServiceListenerInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager\Listener;
 

--- a/src/Listener/ServiceListenerInterface.php
+++ b/src/Listener/ServiceListenerInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager\Listener;

--- a/src/ModuleEvent.php
+++ b/src/ModuleEvent.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager;
 

--- a/src/ModuleEvent.php
+++ b/src/ModuleEvent.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager;

--- a/src/ModuleManager.php
+++ b/src/ModuleManager.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager;
 

--- a/src/ModuleManager.php
+++ b/src/ModuleManager.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager;

--- a/src/ModuleManagerInterface.php
+++ b/src/ModuleManagerInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\ModuleManager;
 

--- a/src/ModuleManagerInterface.php
+++ b/src/ModuleManagerInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ModuleManager;

--- a/test/Listener/AbstractListenerTestCase.php
+++ b/test/Listener/AbstractListenerTestCase.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/AbstractListenerTestCase.php
+++ b/test/Listener/AbstractListenerTestCase.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/AutoloaderListenerTest.php
+++ b/test/Listener/AutoloaderListenerTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/AutoloaderListenerTest.php
+++ b/test/Listener/AutoloaderListenerTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/ConfigListenerTest.php
+++ b/test/Listener/ConfigListenerTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/ConfigListenerTest.php
+++ b/test/Listener/ConfigListenerTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/DefaultListenerAggregateTest.php
+++ b/test/Listener/DefaultListenerAggregateTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/DefaultListenerAggregateTest.php
+++ b/test/Listener/DefaultListenerAggregateTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/InitTriggerTest.php
+++ b/test/Listener/InitTriggerTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/InitTriggerTest.php
+++ b/test/Listener/InitTriggerTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/ListenerOptionsTest.php
+++ b/test/Listener/ListenerOptionsTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/ListenerOptionsTest.php
+++ b/test/Listener/ListenerOptionsTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/LocatorRegistrationListenerTest.php
+++ b/test/Listener/LocatorRegistrationListenerTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/LocatorRegistrationListenerTest.php
+++ b/test/Listener/LocatorRegistrationListenerTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/ModuleDependencyCheckerListenerTest.php
+++ b/test/Listener/ModuleDependencyCheckerListenerTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/ModuleDependencyCheckerListenerTest.php
+++ b/test/Listener/ModuleDependencyCheckerListenerTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/ModuleLoaderListenerTest.php
+++ b/test/Listener/ModuleLoaderListenerTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/ModuleLoaderListenerTest.php
+++ b/test/Listener/ModuleLoaderListenerTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/ModuleResolverListenerTest.php
+++ b/test/Listener/ModuleResolverListenerTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/ModuleResolverListenerTest.php
+++ b/test/Listener/ModuleResolverListenerTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/OnBootstrapListenerTest.php
+++ b/test/Listener/OnBootstrapListenerTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/OnBootstrapListenerTest.php
+++ b/test/Listener/OnBootstrapListenerTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/ServiceListenerTest.php
+++ b/test/Listener/ServiceListenerTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener;
 

--- a/test/Listener/ServiceListenerTest.php
+++ b/test/Listener/ServiceListenerTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener;

--- a/test/Listener/TestAsset/CustomPluginDuckTypeProviderModule.php
+++ b/test/Listener/TestAsset/CustomPluginDuckTypeProviderModule.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;

--- a/test/Listener/TestAsset/CustomPluginDuckTypeProviderModule.php
+++ b/test/Listener/TestAsset/CustomPluginDuckTypeProviderModule.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 

--- a/test/Listener/TestAsset/CustomPluginInterface.php
+++ b/test/Listener/TestAsset/CustomPluginInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;

--- a/test/Listener/TestAsset/CustomPluginInterface.php
+++ b/test/Listener/TestAsset/CustomPluginInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 

--- a/test/Listener/TestAsset/CustomPluginManager.php
+++ b/test/Listener/TestAsset/CustomPluginManager.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;

--- a/test/Listener/TestAsset/CustomPluginManager.php
+++ b/test/Listener/TestAsset/CustomPluginManager.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 

--- a/test/Listener/TestAsset/CustomPluginManagerFactory.php
+++ b/test/Listener/TestAsset/CustomPluginManagerFactory.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
  * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;

--- a/test/Listener/TestAsset/CustomPluginManagerFactory.php
+++ b/test/Listener/TestAsset/CustomPluginManagerFactory.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 

--- a/test/Listener/TestAsset/CustomPluginProviderInterface.php
+++ b/test/Listener/TestAsset/CustomPluginProviderInterface.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;

--- a/test/Listener/TestAsset/CustomPluginProviderInterface.php
+++ b/test/Listener/TestAsset/CustomPluginProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 

--- a/test/Listener/TestAsset/CustomPluginProviderModule.php
+++ b/test/Listener/TestAsset/CustomPluginProviderModule.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;

--- a/test/Listener/TestAsset/CustomPluginProviderModule.php
+++ b/test/Listener/TestAsset/CustomPluginProviderModule.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 

--- a/test/Listener/TestAsset/SampleAbstractFactory.php
+++ b/test/Listener/TestAsset/SampleAbstractFactory.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;

--- a/test/Listener/TestAsset/SampleAbstractFactory.php
+++ b/test/Listener/TestAsset/SampleAbstractFactory.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 

--- a/test/Listener/TestAsset/ServiceInvalidReturnModule.php
+++ b/test/Listener/TestAsset/ServiceInvalidReturnModule.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;

--- a/test/Listener/TestAsset/ServiceInvalidReturnModule.php
+++ b/test/Listener/TestAsset/ServiceInvalidReturnModule.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 

--- a/test/Listener/TestAsset/ServiceProviderModule.php
+++ b/test/Listener/TestAsset/ServiceProviderModule.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;

--- a/test/Listener/TestAsset/ServiceProviderModule.php
+++ b/test/Listener/TestAsset/ServiceProviderModule.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 

--- a/test/Listener/TestAsset/UndefinedProviderInterface.php
+++ b/test/Listener/TestAsset/UndefinedProviderInterface.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;

--- a/test/Listener/TestAsset/UndefinedProviderInterface.php
+++ b/test/Listener/TestAsset/UndefinedProviderInterface.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\Listener\TestAsset;
 

--- a/test/Listener/_files/bad/config.php
+++ b/test/Listener/_files/bad/config.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 $obj = new stdClass;
 return $obj;

--- a/test/Listener/_files/bad/config.php
+++ b/test/Listener/_files/bad/config.php
@@ -1,3 +1,9 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 $obj = new stdClass;
 return $obj;

--- a/test/Listener/_files/good/config.php
+++ b/test/Listener/_files/good/config.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 return [
     'php' => 'loaded',

--- a/test/Listener/_files/good/config.php
+++ b/test/Listener/_files/good/config.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 return [
     'php' => 'loaded',
 ];

--- a/test/Listener/_files/good/merge1.php
+++ b/test/Listener/_files/good/merge1.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 return [
     'indexed' => ['foo'],

--- a/test/Listener/_files/good/merge1.php
+++ b/test/Listener/_files/good/merge1.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 return [
     'indexed' => ['foo'],
     'keyed'   => 'foo',

--- a/test/Listener/_files/good/merge2.php
+++ b/test/Listener/_files/good/merge2.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 return [
     'indexed' => ['bar'],

--- a/test/Listener/_files/good/merge2.php
+++ b/test/Listener/_files/good/merge2.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 return [
     'indexed' => ['bar'],
     'keyed'   => 'bar',

--- a/test/ModuleEventTest.php
+++ b/test/ModuleEventTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager;
 

--- a/test/ModuleEventTest.php
+++ b/test/ModuleEventTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager;

--- a/test/ModuleManagerTest.php
+++ b/test/ModuleManagerTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager;

--- a/test/ModuleManagerTest.php
+++ b/test/ModuleManagerTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager;
 
@@ -62,7 +63,7 @@ class ModuleManagerTest extends TestCase
         $loadedModules = $moduleManager->getLoadedModules();
         $this->assertInstanceOf('SomeModule\Module', $loadedModules['SomeModule']);
         $config = $configListener->getMergedConfig();
-        $this->assertSame($config->some, 'thing', var_export($config, 1));
+        $this->assertSame($config->some, 'thing', var_export($config, true));
     }
 
     public function testCanLoadMultipleModules()

--- a/test/ResetAutoloadFunctionsTrait.php
+++ b/test/ResetAutoloadFunctionsTrait.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager;

--- a/test/ResetAutoloadFunctionsTrait.php
+++ b/test/ResetAutoloadFunctionsTrait.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager;
 
@@ -63,6 +64,6 @@ trait ResetAutoloadFunctionsTrait
      */
     protected function restoreIncludePath()
     {
-        set_include_path($this->includePath);
+        set_include_path((string)$this->includePath);
     }
 }

--- a/test/SetUpCacheDirTrait.php
+++ b/test/SetUpCacheDirTrait.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager;

--- a/test/SetUpCacheDirTrait.php
+++ b/test/SetUpCacheDirTrait.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager;
 
@@ -39,7 +40,10 @@ trait SetUpCacheDirTrait
     protected function removeTmpDir()
     {
         $file = glob($this->tmpdir . DIRECTORY_SEPARATOR . '*');
-        @unlink($file[0]); // change this if there's ever > 1 file
+        if (isset($file[0])) {
+            // change this if there's ever > 1 file
+            @unlink($file[0]);
+        }
         @rmdir($this->tmpdir);
     }
 }

--- a/test/TestAsset/BadConfigModule/Module.php
+++ b/test/TestAsset/BadConfigModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace BadConfigModule;

--- a/test/TestAsset/BadConfigModule/Module.php
+++ b/test/TestAsset/BadConfigModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace BadConfigModule;
 

--- a/test/TestAsset/BafModule/Module.php
+++ b/test/TestAsset/BafModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace BafModule;
 

--- a/test/TestAsset/BafModule/Module.php
+++ b/test/TestAsset/BafModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace BafModule;

--- a/test/TestAsset/BafModule/configs/config.php
+++ b/test/TestAsset/BafModule/configs/config.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 return [
     'bar' => 'foo',

--- a/test/TestAsset/BafModule/configs/config.php
+++ b/test/TestAsset/BafModule/configs/config.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 return [
     'bar' => 'foo',
 ];

--- a/test/TestAsset/BamModule/Module.php
+++ b/test/TestAsset/BamModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace BamModule;
 

--- a/test/TestAsset/BamModule/Module.php
+++ b/test/TestAsset/BamModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace BamModule;

--- a/test/TestAsset/BamModule/configs/config.php
+++ b/test/TestAsset/BamModule/configs/config.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 return [
     'bar' => 'foo',

--- a/test/TestAsset/BamModule/configs/config.php
+++ b/test/TestAsset/BamModule/configs/config.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 return [
     'bar' => 'foo',
 ];

--- a/test/TestAsset/BarModule/Module.php
+++ b/test/TestAsset/BarModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace BarModule;

--- a/test/TestAsset/BarModule/Module.php
+++ b/test/TestAsset/BarModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace BarModule;
 

--- a/test/TestAsset/BarModule/configs/config.php
+++ b/test/TestAsset/BarModule/configs/config.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 return [
     'bar' => 'foo',

--- a/test/TestAsset/BarModule/configs/config.php
+++ b/test/TestAsset/BarModule/configs/config.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 return [
     'bar' => 'foo',
 ];

--- a/test/TestAsset/BazModule/Module.php
+++ b/test/TestAsset/BazModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace BazModule;

--- a/test/TestAsset/BazModule/Module.php
+++ b/test/TestAsset/BazModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace BazModule;
 

--- a/test/TestAsset/BazModule/configs/config.php
+++ b/test/TestAsset/BazModule/configs/config.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 return [
     'baz' => 'bar',

--- a/test/TestAsset/BazModule/configs/config.php
+++ b/test/TestAsset/BazModule/configs/config.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 return [
     'baz' => 'bar',
 ];

--- a/test/TestAsset/BooModule/Module.php
+++ b/test/TestAsset/BooModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace BooModule;

--- a/test/TestAsset/BooModule/Module.php
+++ b/test/TestAsset/BooModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace BooModule;
 

--- a/test/TestAsset/BooModule/configs/config.php
+++ b/test/TestAsset/BooModule/configs/config.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 return [
     'bar' => 'foo',

--- a/test/TestAsset/BooModule/configs/config.php
+++ b/test/TestAsset/BooModule/configs/config.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 return [
     'bar' => 'foo',
 ];

--- a/test/TestAsset/BorModule/Module.php
+++ b/test/TestAsset/BorModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace BorModule;

--- a/test/TestAsset/BorModule/Module.php
+++ b/test/TestAsset/BorModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace BorModule;
 

--- a/test/TestAsset/BorModule/configs/config.php
+++ b/test/TestAsset/BorModule/configs/config.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 return [
     'bar' => 'foo',

--- a/test/TestAsset/BorModule/configs/config.php
+++ b/test/TestAsset/BorModule/configs/config.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 return [
     'bar' => 'foo',
 ];

--- a/test/TestAsset/ListenerTestModule/FooModule.php
+++ b/test/TestAsset/ListenerTestModule/FooModule.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
 
 namespace ListenerTestModule;
 

--- a/test/TestAsset/ListenerTestModule/FooModule.php
+++ b/test/TestAsset/ListenerTestModule/FooModule.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ListenerTestModule;
 

--- a/test/TestAsset/ListenerTestModule/Module.php
+++ b/test/TestAsset/ListenerTestModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ListenerTestModule;

--- a/test/TestAsset/ListenerTestModule/Module.php
+++ b/test/TestAsset/ListenerTestModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ListenerTestModule;
 

--- a/test/TestAsset/ListenerTestModule/src/Foo/Bar.php
+++ b/test/TestAsset/ListenerTestModule/src/Foo/Bar.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Foo;

--- a/test/TestAsset/ListenerTestModule/src/Foo/Bar.php
+++ b/test/TestAsset/ListenerTestModule/src/Foo/Bar.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Foo;
 

--- a/test/TestAsset/LoadBarModule/Module.php
+++ b/test/TestAsset/LoadBarModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace LoadBarModule;
 

--- a/test/TestAsset/LoadBarModule/Module.php
+++ b/test/TestAsset/LoadBarModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace LoadBarModule;

--- a/test/TestAsset/LoadFooModule/Module.php
+++ b/test/TestAsset/LoadFooModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace LoadFooModule;
 

--- a/test/TestAsset/LoadFooModule/Module.php
+++ b/test/TestAsset/LoadFooModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace LoadFooModule;

--- a/test/TestAsset/LoadOtherModule/Module.php
+++ b/test/TestAsset/LoadOtherModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace LoadOtherModule;

--- a/test/TestAsset/LoadOtherModule/Module.php
+++ b/test/TestAsset/LoadOtherModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace LoadOtherModule;
 

--- a/test/TestAsset/MockApplication.php
+++ b/test/TestAsset/MockApplication.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\ModuleManager\TestAsset;
 

--- a/test/TestAsset/MockApplication.php
+++ b/test/TestAsset/MockApplication.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ModuleManager\TestAsset;

--- a/test/TestAsset/ModuleAsClass.php
+++ b/test/TestAsset/ModuleAsClass.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 class ModuleAsClass
 {

--- a/test/TestAsset/ModuleAsClass.php
+++ b/test/TestAsset/ModuleAsClass.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * @see       https://github.com/zendframework/zend-modulemanager for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/TestAsset/ModuleAsClass/Module.php
+++ b/test/TestAsset/ModuleAsClass/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ModuleAsClass;
 

--- a/test/TestAsset/ModuleAsClass/Module.php
+++ b/test/TestAsset/ModuleAsClass/Module.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * @see       https://github.com/zendframework/zend-modulemanager for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/TestAsset/NotAutoloaderModule/Module.php
+++ b/test/TestAsset/NotAutoloaderModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace NotAutoloaderModule;
 

--- a/test/TestAsset/NotAutoloaderModule/Module.php
+++ b/test/TestAsset/NotAutoloaderModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace NotAutoloaderModule;

--- a/test/TestAsset/NotAutoloaderModule/src/Foo/Bar.php
+++ b/test/TestAsset/NotAutoloaderModule/src/Foo/Bar.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace Foo;

--- a/test/TestAsset/NotAutoloaderModule/src/Foo/Bar.php
+++ b/test/TestAsset/NotAutoloaderModule/src/Foo/Bar.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Foo;
 

--- a/test/TestAsset/SomeModule/Module.php
+++ b/test/TestAsset/SomeModule/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace SomeModule;

--- a/test/TestAsset/SomeModule/Module.php
+++ b/test/TestAsset/SomeModule/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace SomeModule;
 

--- a/test/TestAsset/SomeModule/configs/config.php
+++ b/test/TestAsset/SomeModule/configs/config.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 return [
     'some' => 'thing',
 ];

--- a/test/TestAsset/SomeModule/configs/config.php
+++ b/test/TestAsset/SomeModule/configs/config.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 return [
     'some' => 'thing',

--- a/test/TestAsset/SubModule/Sub/Module.php
+++ b/test/TestAsset/SubModule/Sub/Module.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 
 namespace SubModule\Sub;

--- a/test/TestAsset/SubModule/Sub/Module.php
+++ b/test/TestAsset/SubModule/Sub/Module.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace SubModule\Sub;
 

--- a/test/_files/config.php
+++ b/test/_files/config.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
+ */
+
 return [
     'all' => [
         'php' => 'yes'

--- a/test/_files/config.php
+++ b/test/_files/config.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 return [
     'all' => [

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * @see       https://github.com/zendframework/zend-modulemanager for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      http://github.com/zendframework/zend-modulemanager for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-modulemanager/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 if (! class_exists(\PHPUnit_Framework_Assert::class)) {
     class_alias(\PHPUnit\Framework\Assert::class, \PHPUnit_Framework_Assert::class, true);


### PR DESCRIPTION
- Drops php 5.6 and 7.0 support
- Prepares develop for next major
- Updates copyright header
- Declares strict types
