### PR TITLE
Changed onBootstrap return type to void

### DIFF
--- a/src/Feature/BootstrapListenerInterface.php
+++ b/src/Feature/BootstrapListenerInterface.php
@@ -20,7 +20,7 @@ interface BootstrapListenerInterface
      * Listen to the bootstrap event
      *
      * @param EventInterface $e
-     * @return array
+     * @return void
      */
     public function onBootstrap(EventInterface $e);
 }


### PR DESCRIPTION
`onBootstrap` implementation is not expected to return anything.

See [discourse.zendframework.com/t/return-type-of-onbootstrap/573](https://discourse.zendframework.com/t/return-type-of-onbootstrap/573?u=gscscnd).
