### PR TITLE
Bug: Malformed config cache can lead to config data leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.8.3
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#87](https://github.com/zendframework/zend-modulemanager/pull/87) Fixes
+  potential config leak during high loads
+
 ## 2.8.2 - 2017-12-02
 
 ### Added

--- a/src/Listener/ConfigListener.php
+++ b/src/Listener/ConfigListener.php
@@ -10,6 +10,7 @@
 namespace Zend\ModuleManager\Listener;
 
 use Traversable;
+use Throwable;
 use Zend\Config\Config;
 use Zend\Config\Factory as ConfigFactory;
 use Zend\EventManager\EventManagerInterface;
@@ -397,7 +398,11 @@ class ConfigListener extends AbstractListener implements
     {
         // Catch output to prevent malformed config to be returned to browser
         ob_start(null, 0, PHP_OUTPUT_HANDLER_CLEANABLE | PHP_OUTPUT_HANDLER_REMOVABLE);
-        $config = include $this->getOptions()->getConfigCacheFile();
+        try {
+            $config = include $this->getOptions()->getConfigCacheFile();
+        } catch (Throwable $e) {
+            $config = null;
+        }
         $output = ob_get_clean();
 
         if (! empty($output) || ! is_array($config)) {

--- a/src/Listener/ConfigListener.php
+++ b/src/Listener/ConfigListener.php
@@ -9,8 +9,8 @@
 
 namespace Zend\ModuleManager\Listener;
 
-use Traversable;
 use Throwable;
+use Traversable;
 use Zend\Config\Config;
 use Zend\Config\Factory as ConfigFactory;
 use Zend\EventManager\EventManagerInterface;

--- a/test/Listener/ConfigListenerTest.php
+++ b/test/Listener/ConfigListenerTest.php
@@ -373,7 +373,7 @@ class ConfigListenerTest extends AbstractListenerTestCase
 
     public function datasetCachedConfigs()
     {
-        return [
+        $datasets = [
             'valid_file' => [
                 // Test for check if cache is properly used if is valid
                 ['data' => 'any'], // expects to fall back to loading all modules
@@ -391,11 +391,14 @@ class ConfigListenerTest extends AbstractListenerTestCase
                 ['some' => 'thing', 'listener' => 'test'], // expects to fall back to loading all modules
                 '<\?php return [\'data\' => \'any\'];',
             ],
-            'invalid_file_syntax' => [
+        ];
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            $datasets['invalid_file_syntax'] = [
                 ['some' => 'thing', 'listener' => 'test'], // expects to fall back to loading all modules
                 '<?php return (???\'data\' => \'any\');',
-            ],
-        ];
+            ];
+        }
+        return $datasets;
     }
 
     /**

--- a/test/Listener/ConfigListenerTest.php
+++ b/test/Listener/ConfigListenerTest.php
@@ -391,6 +391,10 @@ class ConfigListenerTest extends AbstractListenerTestCase
                 ['some' => 'thing', 'listener' => 'test'], // expects to fall back to loading all modules
                 '<\?php return [\'data\' => \'any\'];',
             ],
+            'invalid_file_syntax' => [
+                ['some' => 'thing', 'listener' => 'test'], // expects to fall back to loading all modules
+                '<?php return (???\'data\' => \'any\');',
+            ],
         ];
     }
 

--- a/test/Listener/ConfigListenerTest.php
+++ b/test/Listener/ConfigListenerTest.php
@@ -402,6 +402,8 @@ class ConfigListenerTest extends AbstractListenerTestCase
     }
 
     /**
+     * @param array $expectedConfig Expected config array after load
+     * @param string|null $cacheContents Contents of cache config file, null means "no file"
      * @dataProvider datasetCachedConfigs
      */
     public function testDoesNotReturnConfigToOutputIfFileIsMalformed(
@@ -410,7 +412,6 @@ class ConfigListenerTest extends AbstractListenerTestCase
     ) {
         $tempDir = sys_get_temp_dir();
         $cacheConfigFile = $tempDir . '/module-config-cache.php';
-        $staticConfigFile = $tempDir . '/module-config-static.php';
 
         if (file_exists($cacheConfigFile)) {
             unlink($cacheConfigFile);
@@ -422,13 +423,6 @@ class ConfigListenerTest extends AbstractListenerTestCase
                 $this->markTestSkipped('Running system does not allow writing to temp directory');
                 return;
             }
-        }
-
-        // Prepare static config to check if config falled back to static autoloading when cache is malformed
-        $fileCreated = file_put_contents($staticConfigFile, '<?php return [\'static\' => true];');
-        if ($fileCreated === false) {
-            $this->markTestSkipped('Running system does not allow writing to temp directory');
-            return;
         }
 
         // Set cached config to be stored inside system temporary directory
@@ -456,9 +450,6 @@ class ConfigListenerTest extends AbstractListenerTestCase
             // Cleanup
             if (file_exists($cacheConfigFile)) {
                 unlink($cacheConfigFile);
-            }
-            if (file_exists($staticConfigFile)) {
-                unlink($staticConfigFile);
             }
             $output = ob_get_clean();
         }

--- a/test/Listener/ConfigListenerTest.php
+++ b/test/Listener/ConfigListenerTest.php
@@ -402,8 +402,8 @@ class ConfigListenerTest extends AbstractListenerTestCase
      * @dataProvider datasetCachedConfigs
      */
     public function testDoesNotReturnConfigToOutputIfFileIsMalformed(
-        array $expectedConfig,
-        string $cacheContents = null
+        $expectedConfig,
+        $cacheContents
     ) {
         $tempDir = sys_get_temp_dir();
         $cacheConfigFile = $tempDir . '/module-config-cache.php';


### PR DESCRIPTION
**Bug description**:

There are two significant cases: 

1. When config **cache is malformed** module will send file contents to browser which may lead to config data leak.<br>
Example malformed file
```
<\?php
return ['something' => true];
```
2. When config **cache is written by another process**, module manager will read partially written file and fail on loading it as `include` will throw f.x. `ParseError` what will stop module manager execution.<br>
Example partially written file
```
<?php
return [
```
One blocking example is having only `<?php` inside cache config as it will result in returning `1` by `include` instruction what in next steps will be rejected by `setMergedConfig` and will result in `TypeError`.<br>
Example partially written file

**Source of bug**

I have seen second scenario in my production environment. It was result of clearing this cache from time to time but can be expected to occur during high loads on file system. We started analysis from following error:

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Zend\ModuleManager\Listener\ConfigListener::setMergedConfig() must be of the type array, integer given
```

**Tests proving bug**

Added to `ConfigListenerTest` as `testDoesNotReturnConfigToOutputIfFileIsMalformed`.

**Expected behaviour**

Module manager will fall back into loading all configs from modules paths when config cache cannot be read as array.