### PR TITLE
Write cache to temporary file first and then rename

### DIFF
--- a/src/Listener/AbstractListener.php
+++ b/src/Listener/AbstractListener.php
@@ -61,8 +61,16 @@ abstract class AbstractListener
      */
     protected function writeArrayToFile($filePath, $array)
     {
+        // Write cache file to temporary file first and then rename it.
+        // We don't want cache file to be read when it is not written completely.
+        // include/require functions require additional lock, see:
+        // https://bugs.php.net/bug.php?id=52895
+        $tmp = tempnam(sys_get_temp_dir(), md5($filePath));
+
         $content = "<?php\nreturn " . var_export($array, 1) . ';';
-        file_put_contents($filePath, $content, LOCK_EX);
+        file_put_contents($tmp, $content);
+        rename($tmp, $filePath);
+
         return $this;
     }
 }


### PR DESCRIPTION
Alternative solution for issue reported in #87.

The problem is that every process running process check if the cache file exists and if it doesn't it tries to create it. In case of big configuration creating cache file can take a while. And while it is generated other process can read "malformed" file, which is the issue.

As locking file does not work out of the box with include/require (see: https://bugs.php.net/bug.php?id=52895) we can add flock around include/require (where the cache file is read) or apply the solution from this PR.

Not sure how we can test it in a right and easy way.
Also, not sure if locking solution is gonna be better - how we can measure performance of both approaches?

/cc @rutek @Xerkus 