### PR TITLE
Hotfix: set correct permission on cache file

### DIFF
--- a/src/Listener/AbstractListener.php
+++ b/src/Listener/AbstractListener.php
@@ -67,6 +67,8 @@ abstract class AbstractListener
 
         $content = "<?php\nreturn " . var_export($array, true) . ';';
         file_put_contents($tmp, $content);
+        chmod($tmp, 0666 & ~umask());
+
         rename($tmp, $filePath);
 
         return $this;


### PR DESCRIPTION
tempnam creates file with 0600 permission and it can cause issue
on some environments when different user is generating the cache file
and then different user try to get access to it.

Resolve #90
